### PR TITLE
[Feat] 카테고리 목록 API 명세 작성 및 기능 구현, 카테고리 상세 페이지 API 명세 작성

### DIFF
--- a/src/main/java/com/grabpt/controller/CategoryRestController.java
+++ b/src/main/java/com/grabpt/controller/CategoryRestController.java
@@ -1,0 +1,112 @@
+package com.grabpt.controller;
+
+import com.grabpt.apiPayload.ApiResponse;
+import com.grabpt.converter.CategoryConverter;
+import com.grabpt.domain.entity.Category;
+import com.grabpt.domain.enums.RequestStatus;
+import com.grabpt.dto.CategoryResponse;
+import com.grabpt.service.CategoryService.CategoryQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CategoryRestController {
+
+	private final CategoryQueryService categoryQueryService;
+
+	@Operation(
+		summary = "카테고리 목록 조회 API",
+		description = "카테고리의 목록을 조회하는 API"
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
+	@GetMapping("/categories")
+	public ApiResponse<List<CategoryResponse.CategoryListDto>> getCategoryList() {
+		List<Category> categories = categoryQueryService.getCategories();
+		return ApiResponse.onSuccess(CategoryConverter.toCategoryListDto(categories));
+	}
+
+	@Operation(
+		summary = "카테고리 상세 페이지 조회(전문가 목록 조회)",
+		description = "카테고리 상세 페이지 중 전문가 목록을 조회하는 API(페이징 포함), 로그아웃 상태일 때 region을 쿼리파라미터로 전달"
+	)
+	@Parameters({
+		@Parameter(name = "code", description = "카테고리 코드 (예: box)", required = true, in = ParameterIn.PATH, example = "box"),
+		@Parameter(name = "region", description = "지역명 (예: 화곡3동)", required = false, example = "화곡3동"),
+		@Parameter(name = "page", description = "페이지 번호 1부터 시작)", required = false, example = "1")
+	})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",
+			description = "전문가 목록 조회 성공",
+			content = @Content(mediaType = "application/json",
+				schema = @Schema(implementation = CategoryResponse.TrainerPreviewListDto.class))
+		),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
+	@GetMapping("/category/{code}/trainers")
+	public ApiResponse<CategoryResponse.TrainerPreviewListDto> getTrainerList(
+		@PathVariable(name = "code") String code,
+		@RequestParam(name = "region", required = false) String region,
+		@RequestParam(defaultValue = "1") int page) {
+
+		Pageable pageable = PageRequest.of(page-1, 4, Sort.by("rating").descending());
+		return ApiResponse.onSuccess(new CategoryResponse.TrainerPreviewListDto(null, 0, 0, 0L, true, true));
+	}
+
+	@Operation(
+		summary = "요청서 목록 조회 (카테고리별)",
+		description = "카테고리 코드에 해당하는 요청서 목록을 최신순으로 6개를 보여줍니다, 지역은 전국 단위입니다"
+	)
+	@Parameters({
+		@Parameter(name = "code", description = "카테고리 코드 (예: box)", required = true, in = ParameterIn.PATH, example = "box"),
+	})
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+			responseCode = "200",
+			description = "요청서 목록 조회 성공",
+			content = @Content(mediaType = "application/json",
+				schema = @Schema(implementation = CategoryResponse.RequestListDto.class))
+		),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
+	@GetMapping("/requests/{code}")
+	public ApiResponse<List<CategoryResponse.RequestListDto>> getRequestList(@PathVariable(name = "code") String code) {
+		//예시 값
+		List<CategoryResponse.RequestListDto> dummyList = List.of(
+			CategoryResponse.RequestListDto.builder()
+				.id(1L)
+				.nickname("홍길동")
+				.region("서울시 동작구 상도1동")
+				.sessionCount(3)
+				.totalPrice(120000)
+				.matchStatus(RequestStatus.MATCHING)
+				.profileImageUrl("https://example.com/images/profile1.jpg")
+				.build());
+
+		return ApiResponse.onSuccess(dummyList);
+	}
+
+
+}

--- a/src/main/java/com/grabpt/converter/CategoryConverter.java
+++ b/src/main/java/com/grabpt/converter/CategoryConverter.java
@@ -1,0 +1,21 @@
+package com.grabpt.converter;
+
+import com.grabpt.domain.entity.Category;
+import com.grabpt.dto.CategoryResponse;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CategoryConverter {
+
+	public static List<CategoryResponse.CategoryListDto> toCategoryListDto(List<Category> categories){
+		return categories.stream()
+			.map(category -> CategoryResponse.CategoryListDto.builder()
+				.categoryId(category.getId())
+				.categoryName(category.getName())
+				.build())
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/grabpt/dto/CategoryRequest.java
+++ b/src/main/java/com/grabpt/dto/CategoryRequest.java
@@ -1,0 +1,7 @@
+package com.grabpt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class CategoryRequest {
+}

--- a/src/main/java/com/grabpt/dto/CategoryResponse.java
+++ b/src/main/java/com/grabpt/dto/CategoryResponse.java
@@ -1,0 +1,72 @@
+package com.grabpt.dto;
+
+import com.grabpt.domain.enums.RequestStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class CategoryResponse {
+
+	//카테고리 목록을 위한 DTO
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class CategoryListDto{
+		Long categoryId;
+		String categoryName;
+		//String iconUrl;
+	}
+
+
+	//전문가 목록 조회를 위한 DTO
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class TrainerPreviewListDto{
+		List<CategoryResponse.TrainerPreviewDto> trainerList;
+		Integer listSize;
+		Integer totalPage;
+		Long totalElements;
+		Boolean isFirst;
+		Boolean isLast;
+	}
+
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class TrainerPreviewDto{
+		Long id;
+		String name;
+		double rating;
+		CenterDto centerDto;
+		int pricePerSession;
+		String profileImageUrl;
+	}
+
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class CenterDto{
+		String name;
+		String address;
+	}
+
+	//요청서 목록을 위한 Dto
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	public static class RequestListDto{
+		Long id;
+		String nickname;
+		String region;
+		int sessionCount;
+		int totalPrice;
+		RequestStatus matchStatus;
+		String profileImageUrl;
+	}
+
+
+
+}

--- a/src/main/java/com/grabpt/repository/CategoryRepository.java
+++ b/src/main/java/com/grabpt/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.grabpt.repository;
+
+import com.grabpt.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category,Long> {
+}

--- a/src/main/java/com/grabpt/service/CategoryService/CategoryQueryService.java
+++ b/src/main/java/com/grabpt/service/CategoryService/CategoryQueryService.java
@@ -1,0 +1,11 @@
+package com.grabpt.service.CategoryService;
+
+import com.grabpt.domain.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CategoryQueryService {
+	List<Category> getCategories();
+}

--- a/src/main/java/com/grabpt/service/CategoryService/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/grabpt/service/CategoryService/CategoryQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.grabpt.service.CategoryService;
+
+import com.grabpt.domain.entity.Category;
+import com.grabpt.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryQueryServiceImpl implements CategoryQueryService{
+
+	private final CategoryRepository categoryRepository;
+
+	@Override
+	public List<Category> getCategories() {
+		return categoryRepository.findAll();
+	}
+}


### PR DESCRIPTION
## PR 제목
- [Feat] 카테고리 목록 API 명세 작성 및 기능 구현, 카테고리 상세 페이지 API 명세 작성

## 변경 사항
-카테고리 목록 페이지 API 명세서 작성 (Controller, Dto)
-카테고리 목록 관련 기능 구현 (Service, Repository, Converter)
-카테고리 상세 페이지(전문가 목록) API 명세서 작성 (Controller, Dto)
-카테고리 상세 페이지(요청서 목록) API 명세서 작성 (Controller, Dto)

## 작업 내용 체크
- 기능 동작 확인
- 테스트 코드 작성
- 코드 리뷰 반영

## 관련 이슈
- 관련 이슈 번호: #9

## 기타 공유 사항
- 카테고리 상세 페이지에 대한 기능 구현은 엔티티 작업이 완료 된 후 진행할 예정입니다.
- swagger작성 양식 통일을 위해 얘기해보면 좋을 것 같습니다.
