### PR TITLE
[Feat] 제안서 목록 조회, 요청서 조회 구현

### DIFF
--- a/src/main/java/com/grabpt/controller/AuthController.java
+++ b/src/main/java/com/grabpt/controller/AuthController.java
@@ -104,6 +104,8 @@ public class AuthController {
 			userDetails, null, userDetails.getAuthorities());
 		String newAccessToken = jwtTokenProvider.generateToken(authentication);
 		String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
+		log.info("재발급된 accessToken = " + newAccessToken);
+		log.info("재발급된 refreshToken = " + newRefreshToken);
 
 		user.setRefreshToken(newRefreshToken);
 		userRepository.save(user);

--- a/src/main/java/com/grabpt/controller/RequestionController.java
+++ b/src/main/java/com/grabpt/controller/RequestionController.java
@@ -1,8 +1,8 @@
 package com.grabpt.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +17,7 @@ import com.grabpt.dto.request.RequestionRequestDto;
 import com.grabpt.dto.response.RequestionResponseDto;
 import com.grabpt.dto.response.UserResponseDto;
 import com.grabpt.service.RequestionService.RequestionService;
+import com.grabpt.service.SuggestionService.SuggestionService;
 import com.grabpt.service.UserService.UserQueryService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +33,7 @@ public class RequestionController {
 
 	private final RequestionService requestionService;
 	private final UserQueryService userQueryService;
+	private final SuggestionService suggestionService;
 
 	@Operation(
 		summary = "요청서 작성 저장 API",
@@ -66,12 +68,15 @@ public class RequestionController {
 		description = "트레이너 기준 일반 유저의 요청서를 조회합니다."
 	)
 	public ApiResponse<Page<RequestionResponseDto.RequestionResponsePagingDto>> getRequestionsNearby(
-		@RequestParam(defaultValue = "latest") String sortBy, // 'latest' 또는 'price'
-		@PageableDefault(size = 4) Pageable pageable,
+		@RequestParam(defaultValue = "latest or price") String sortBy,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "4") int size,
 		HttpServletRequest request
 	) throws IllegalAccessException {
-		Page<RequestionResponseDto.RequestionResponsePagingDto> response = requestionService.getNearbyRequestions(
-			request, sortBy, pageable);
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+		Page<RequestionResponseDto.RequestionResponsePagingDto> response =
+			requestionService.getNearbyRequestions(request, sortBy, pageable);
 		return ApiResponse.onSuccess(response);
 	}
+
 }

--- a/src/main/java/com/grabpt/controller/SuggestionController.java
+++ b/src/main/java/com/grabpt/controller/SuggestionController.java
@@ -53,8 +53,7 @@ public class SuggestionController {
 		description = "제안서 정보와 트레이너 프로필 정보를 조회합니다."
 	)
 	public ApiResponse<SuggestionResponseDto.SuggestionDetailResponseDto> getSuggestionDetail(
-		@PathVariable Long suggestionId
-	) {
+		@PathVariable Long suggestionId) {
 		SuggestionResponseDto.SuggestionDetailResponseDto response = suggestionService.getDetail(suggestionId);
 		return ApiResponse.onSuccess(response);
 	}
@@ -63,14 +62,14 @@ public class SuggestionController {
 		summary = "요청서에 대한 제안서 목록 조회 API",
 		description = "요청서 ID에 해당하는 제안서들을 6개씩 페이징하여 조회합니다."
 	)
-	@GetMapping("/requestion/{requestionId}")
+	@GetMapping("/requestionList/{requestionId}")
 	public ApiResponse<Page<SuggestionResponseDto.SuggestionResponsePagingDto>> getSuggestionsByRequestion(
 		@PathVariable Long requestionId,
-		@RequestParam(defaultValue = "0") int page
+		@RequestParam(defaultValue = "1") int page
 	) {
-		Page<SuggestionResponseDto.SuggestionResponsePagingDto> result = suggestionService.getSuggestionsByRequestionId(
-			requestionId, page);
+		int adjustedPage = Math.max(page - 1, 0);
+		Page<SuggestionResponseDto.SuggestionResponsePagingDto> result =
+			suggestionService.getSuggestionsByRequestionId(requestionId, adjustedPage);
 		return ApiResponse.onSuccess(result);
 	}
-
 }

--- a/src/main/java/com/grabpt/controller/SuggestionController.java
+++ b/src/main/java/com/grabpt/controller/SuggestionController.java
@@ -1,10 +1,12 @@
 package com.grabpt.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.grabpt.apiPayload.ApiResponse;
@@ -55,6 +57,20 @@ public class SuggestionController {
 	) {
 		SuggestionResponseDto.SuggestionDetailResponseDto response = suggestionService.getDetail(suggestionId);
 		return ApiResponse.onSuccess(response);
+	}
+
+	@Operation(
+		summary = "요청서에 대한 제안서 목록 조회 API",
+		description = "요청서 ID에 해당하는 제안서들을 6개씩 페이징하여 조회합니다."
+	)
+	@GetMapping("/requestion/{requestionId}")
+	public ApiResponse<Page<SuggestionResponseDto.SuggestionResponsePagingDto>> getSuggestionsByRequestion(
+		@PathVariable Long requestionId,
+		@RequestParam(defaultValue = "0") int page
+	) {
+		Page<SuggestionResponseDto.SuggestionResponsePagingDto> result = suggestionService.getSuggestionsByRequestionId(
+			requestionId, page);
+		return ApiResponse.onSuccess(result);
 	}
 
 }

--- a/src/main/java/com/grabpt/converter/SuggestionConverter.java
+++ b/src/main/java/com/grabpt/converter/SuggestionConverter.java
@@ -1,0 +1,27 @@
+package com.grabpt.converter;
+
+import org.springframework.data.domain.Page;
+
+import com.grabpt.domain.entity.Suggestions;
+import com.grabpt.dto.response.SuggestionResponseDto;
+
+public class SuggestionConverter {
+
+	public static Page<SuggestionResponseDto.SuggestionResponsePagingDto> toSuggestionResponsePageDto(
+		Page<Suggestions> suggestionsPage) {
+
+		return suggestionsPage.map(s -> {
+			var pro = s.getProProfile();
+			var user = pro.getUser();
+			var address = user.getAddress();
+
+			return SuggestionResponseDto.SuggestionResponsePagingDto.builder()
+				.nickname(user.getNickname())
+				.center(pro.getCenter())
+				.address(address != null ? address.getFullAddress() : "")
+				.price(s.getPrice())
+				.averageRate(pro.getAverageRating())
+				.build();
+		});
+	}
+}

--- a/src/main/java/com/grabpt/domain/entity/Address.java
+++ b/src/main/java/com/grabpt/domain/entity/Address.java
@@ -38,4 +38,23 @@ public class Address {
 	@OneToOne
 	@JoinColumn(name = "user_id", unique = true)
 	private Users user;
+
+	public String getFullAddress() {
+		StringBuilder fullAddress = new StringBuilder();
+
+		if (city != null && !city.isBlank()) {
+			fullAddress.append(city).append(" ");
+		}
+		if (district != null && !district.isBlank()) {
+			fullAddress.append(district).append(" ");
+		}
+		if (street != null && !street.isBlank()) {
+			fullAddress.append(street).append(" ");
+		}
+		if (specAddress != null && !specAddress.isBlank()) {
+			fullAddress.append(specAddress);
+		}
+
+		return fullAddress.toString().trim();
+	}
 }

--- a/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
+++ b/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
@@ -1,9 +1,6 @@
 package com.grabpt.dto.response;
 
-import java.time.LocalDateTime;
-
-import com.grabpt.domain.entity.Suggestions;
-import com.grabpt.domain.entity.Users;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,32 +17,18 @@ public class SuggestionResponseDto {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	public static class SuggestionDetailResponseDto {
-
-		private Long suggestionId;
-		private Integer price;
-		private String message;
-		private String location;
-		private LocalDateTime sentAt;
-		private Boolean isAgreed;
-
-		// 프로 유저 정보
 		private String nickname;
+		private String center;
 		private String profileImageUrl;
 
-		public static SuggestionDetailResponseDto from(Suggestions s) {
-			Users proUser = s.getProProfile().getUser();
+		private Integer suggestedPrice;
+		private Integer originalPrice;
+		private Integer discountAmount; // = original - suggested
+		private Boolean isDiscounted;   // true if discount exists
 
-			return SuggestionDetailResponseDto.builder()
-				.suggestionId(s.getId())
-				.price(s.getPrice())
-				.message(s.getMessage())
-				.location(s.getLocation())
-				.sentAt(s.getSentAt())
-				.isAgreed(s.getIsAgreed())
-				.nickname(proUser.getNickname())
-				.profileImageUrl(proUser.getProfileImageUrl())
-				.build();
-		}
+		private String message;
+		private String location;
+		private List<String> photoUrls; // 트레이너 제안 사진들
 	}
 
 	@Getter

--- a/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
+++ b/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Data
 public class SuggestionResponseDto {
@@ -46,4 +47,18 @@ public class SuggestionResponseDto {
 				.build();
 		}
 	}
+
+	@Getter
+	@Setter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class SuggestionResponsePagingDto {
+		private String nickname;
+		private String center;
+		private String address;
+		private Integer price;
+		private Double averageRate; // 평점 추가
+	}
+
 }

--- a/src/main/java/com/grabpt/repository/SuggestionRepository/SuggestionRepository.java
+++ b/src/main/java/com/grabpt/repository/SuggestionRepository/SuggestionRepository.java
@@ -1,8 +1,11 @@
 package com.grabpt.repository.SuggestionRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grabpt.domain.entity.Suggestions;
 
 public interface SuggestionRepository extends JpaRepository<Suggestions, Long> {
+	Page<Suggestions> findByRequestionId(Long requestionId, Pageable pageable);
 }

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionService.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionService.java
@@ -1,5 +1,7 @@
 package com.grabpt.service.SuggestionService;
 
+import org.springframework.data.domain.Page;
+
 import com.grabpt.domain.entity.Suggestions;
 import com.grabpt.dto.request.SuggestionRequestDto;
 import com.grabpt.dto.response.SuggestionResponseDto;
@@ -9,4 +11,6 @@ public interface SuggestionService {
 	Suggestions save(SuggestionRequestDto dto, String email);
 
 	SuggestionResponseDto.SuggestionDetailResponseDto getDetail(Long suggestionId);
+
+	Page<SuggestionResponseDto.SuggestionResponsePagingDto> getSuggestionsByRequestionId(Long requestionId, int page);
 }

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -2,6 +2,9 @@ package com.grabpt.service.SuggestionService;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.grabpt.apiPayload.code.status.ErrorStatus;
@@ -9,6 +12,7 @@ import com.grabpt.apiPayload.exception.handler.ProHandler;
 import com.grabpt.apiPayload.exception.handler.RequestionHandler;
 import com.grabpt.apiPayload.exception.handler.SuggestionHandler;
 import com.grabpt.apiPayload.exception.handler.UserHandler;
+import com.grabpt.converter.SuggestionConverter;
 import com.grabpt.domain.entity.ProProfile;
 import com.grabpt.domain.entity.Requestions;
 import com.grabpt.domain.entity.Suggestions;
@@ -61,5 +65,14 @@ public class SuggestionServiceImpl implements SuggestionService {
 		Suggestions suggestion = suggestionRepository.findById(suggestionId)
 			.orElseThrow(() -> new SuggestionHandler(ErrorStatus.SUGGESTION_NOT_FOUND));
 		return SuggestionResponseDto.SuggestionDetailResponseDto.from(suggestion);
+	}
+	
+	@Override
+	public Page<SuggestionResponseDto.SuggestionResponsePagingDto> getSuggestionsByRequestionId(Long requestionId,
+		int page) {
+		Pageable pageable = PageRequest.of(page, 6); // 6개씩 페이징
+		Page<Suggestions> suggestionsPage = suggestionRepository.findByRequestionId(requestionId, pageable);
+
+		return SuggestionConverter.toSuggestionResponsePageDto(suggestionsPage);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,16 +14,10 @@ spring:
   config:
     import: optional:file:.env.properties
 
-  #  datasource:
-  #    url: jdbc:mysql://grabptdb.cl4e0asq8fu0.ap-northeast-2.rds.amazonaws.com:3306/grabpt
-  #    username: root
-  #    password: ${GRABPTDB_PASSWORD}
-  #    driver-class-name: com.mysql.cj.jdbc.Driver
-
   datasource:
-    url: jdbc:mysql://localhost:3306/grabpt_db
-    username: grabpt
-    password: 1111
+    url: jdbc:mysql://grabptdb.cl4e0asq8fu0.ap-northeast-2.rds.amazonaws.com:3306/grabpt
+    username: root
+    password: ${GRABPTDB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,16 +14,22 @@ spring:
   config:
     import: optional:file:.env.properties
 
+  #  datasource:
+  #    url: jdbc:mysql://grabptdb.cl4e0asq8fu0.ap-northeast-2.rds.amazonaws.com:3306/grabpt
+  #    username: root
+  #    password: ${GRABPTDB_PASSWORD}
+  #    driver-class-name: com.mysql.cj.jdbc.Driver
+
   datasource:
-    url: jdbc:mysql://grabptdb.cl4e0asq8fu0.ap-northeast-2.rds.amazonaws.com:3306/grabpt
-    username: root
-    password: ${GRABPTDB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/grabpt_db
+    username: grabpt
+    password: 1111
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## PR 제목
- [Feat] 제안서 목록 조회, 요청서 조회 구현

## 변경 사항
- 일반 사용자가 작성한 요청서에 들어온 제안서 조회 구현
- 트레이너 기준 현재 지역에 존재하는 요청서 조회 구현
  - 최신순과 가격높은순 조회 가능
- 페이징 0 -> 1부터조회하도록 변경

## 작업 내용 체크
- 빌드 확인
- Swagger 동작 확인

## 관련 이슈
- [[Feat] 요청서 작성, 제안서 작성 구현 #21](https://github.com/grabPT/grabPT-backend/issues/21)

## 기타 공유 사항
- 
