### PR TITLE
[Feat] 정산 로직 수정 및 프로필사진 저장 로직 수정

### DIFF
--- a/src/main/java/com/grabpt/controller/AuthController.java
+++ b/src/main/java/com/grabpt/controller/AuthController.java
@@ -39,7 +39,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Slf4j
 public class AuthController {

--- a/src/main/java/com/grabpt/controller/OrderController.java
+++ b/src/main/java/com/grabpt/controller/OrderController.java
@@ -22,8 +22,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Controller
 @Slf4j
+@Controller
 @RequiredArgsConstructor
 public class OrderController {
 
@@ -84,7 +84,9 @@ public class OrderController {
 		String userEmail = userQueryService.getUserInfo(request).getEmail();
 		Users user = userQueryService.findByEmail(userEmail).get();
 		log.info("price = " + req.getPrice());
-		Order customOrder = orderService.customOrder(user, req.getPrice(), req.getItemName());
+
+		//  matchingId 전달
+		Order customOrder = orderService.customOrder(user, req.getPrice(), req.getItemName(), req.getMatchingId());
 
 		String message = "주문 실패";
 		if (customOrder != null) {

--- a/src/main/java/com/grabpt/controller/RequestionController.java
+++ b/src/main/java/com/grabpt/controller/RequestionController.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/requestion")
+@RequestMapping("api/requestion")
 @RequiredArgsConstructor
 @Slf4j
 public class RequestionController {

--- a/src/main/java/com/grabpt/controller/SettlementController.java
+++ b/src/main/java/com/grabpt/controller/SettlementController.java
@@ -1,8 +1,9 @@
 package com.grabpt.controller;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.grabpt.apiPayload.ApiResponse;
 import com.grabpt.apiPayload.code.status.ErrorStatus;
@@ -20,8 +21,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Controller
 @Slf4j
+@RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class SettlementController {
 

--- a/src/main/java/com/grabpt/controller/SmsController.java
+++ b/src/main/java/com/grabpt/controller/SmsController.java
@@ -20,7 +20,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/sms")
+@RequestMapping("/api/sms")
 @RequiredArgsConstructor
 public class SmsController {
 

--- a/src/main/java/com/grabpt/controller/SuggestionController.java
+++ b/src/main/java/com/grabpt/controller/SuggestionController.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@RequestMapping("/suggestion")
+@RequestMapping("/api/suggestion")
 @RequiredArgsConstructor
 @Slf4j
 public class SuggestionController {

--- a/src/main/java/com/grabpt/controller/UserRestController.java
+++ b/src/main/java/com/grabpt/controller/UserRestController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/users")
 public class UserRestController {
 
 	private final UserQueryService userQueryService;

--- a/src/main/java/com/grabpt/domain/entity/Order.java
+++ b/src/main/java/com/grabpt/domain/entity/Order.java
@@ -44,11 +44,12 @@ public class Order extends BaseEntity {
 	private Matching matching; // 어떤 매칭에서 발생한 결제인지 (1:N)
 
 	@Builder
-	public Order(Long price, String itemName, String orderUid, Users user, Payment payment) {
+	public Order(Long price, String itemName, String orderUid, Users user, Payment payment, Matching matching) {
 		this.price = price;
 		this.itemName = itemName;
 		this.orderUid = orderUid;
 		this.user = user;
 		this.payment = payment;
+		this.matching = matching;
 	}
 }

--- a/src/main/java/com/grabpt/domain/entity/Payment.java
+++ b/src/main/java/com/grabpt/domain/entity/Payment.java
@@ -4,6 +4,8 @@ import com.grabpt.domain.common.BaseEntity;
 import com.grabpt.domain.enums.PaymentStatus;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,8 +21,12 @@ public class Payment extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
 	private Long price;
+
+	@Enumerated(EnumType.STRING)
 	private PaymentStatus status;
+	
 	private String paymentUid; // 결제 고유 번호
 
 	@Builder

--- a/src/main/java/com/grabpt/dto/request/ImPortRequestDto.java
+++ b/src/main/java/com/grabpt/dto/request/ImPortRequestDto.java
@@ -73,6 +73,7 @@ public class ImPortRequestDto {
 	public static class CustomOrderRequestDto {
 		private Long price; // 결제 고유 번호
 		private String itemName; // 주문 고유 번호
+		private Long matchingId;
 	}
 
 	@Getter

--- a/src/main/java/com/grabpt/repository/OrderRepository/OrderRepository.java
+++ b/src/main/java/com/grabpt/repository/OrderRepository/OrderRepository.java
@@ -49,15 +49,16 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		"r.sessionCount, " +
 		"o.price, " +
 		"o.price, " +
-		"o.createdAt) " +
+		"p.createdAt) " +
 		"FROM Order o " +
+		"JOIN o.payment p " +
 		"JOIN o.matching m " +
 		"JOIN m.suggestion s " +
 		"JOIN m.requestion r " +
 		"JOIN r.user u " +
 		"WHERE s.proProfile.id = :proProfileId " +
-		"AND o.payment.status = :status " +
-		"ORDER BY o.createdAt DESC")
+		"AND p.status = :status " +
+		"ORDER BY p.createdAt DESC")
 	Page<MemberPaymentDto> getMemberPayments(@Param("proProfileId") Long proProfileId,
 		@Param("status") PaymentStatus status,
 		Pageable pageable);

--- a/src/main/java/com/grabpt/service/AuthService/AuthService.java
+++ b/src/main/java/com/grabpt/service/AuthService/AuthService.java
@@ -11,11 +11,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.grabpt.apiPayload.code.status.ErrorStatus;
+import com.grabpt.apiPayload.exception.handler.CategoryHandler;
 import com.grabpt.apiPayload.exception.handler.UserHandler;
 import com.grabpt.aws.s3.AmazonS3Manager;
 import com.grabpt.aws.s3.Uuid;
 import com.grabpt.config.jwt.JwtTokenProvider;
+import com.grabpt.domain.entity.Address;
+import com.grabpt.domain.entity.Category;
+import com.grabpt.domain.entity.ProProfile;
 import com.grabpt.domain.entity.Terms;
+import com.grabpt.domain.entity.UserProfile;
 import com.grabpt.domain.entity.UserTermsAgreement;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.AuthRole;
@@ -44,6 +49,196 @@ public class AuthService {
 	private final TermsRepository termsRepository;
 	private final UserTermsAgreementRepository userTermsAgreementRepository;
 	private final AmazonS3Manager amazonS3Manager;
+
+	public void registerUser_photo(SignupRequest.UserSignupRequestDto req,
+		MultipartFile profileImage,
+		HttpServletResponse response) {
+
+		// 프로필 사진 S3 업로드
+		String imageUrl = null;
+		if (profileImage != null && !profileImage.isEmpty()) {
+			Uuid uuid = Uuid.builder().uuid(UUID.randomUUID().toString()).build();
+			String keyName = amazonS3Manager.generateProfilePhotoKeyName(uuid);
+			imageUrl = amazonS3Manager.uploadFile(keyName, profileImage);
+		}
+
+		// 카테고리 조회
+		Category userCategory = categoryRepository.findById(req.getCategoryId())
+			.orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+
+		// UserProfile 생성
+		UserProfile userProfile = UserProfile.builder()
+			.category(userCategory)
+			.build();
+
+		// Address 생성
+		SignupRequest.UserSignupRequestDto.AddressRequest addressDto = req.getAddress();
+		Address address = Address.builder()
+			.city(addressDto.getCity())
+			.district(addressDto.getDistrict())
+			.street(addressDto.getStreet())
+			.zipcode(addressDto.getZipcode())
+			.streetCode(addressDto.getStreetCode())
+			.specAddress(addressDto.getSpecAddress())
+			.build();
+
+		// Users 생성 및 연관관계 설정
+		Users user = Users.builder()
+			.username(req.getUsername())
+			.email(req.getEmail())
+			.phone_number(req.getPhoneNum())
+			.address(address)
+			.nickname(req.getNickname())
+			.role(mapToRole(req.getRole()))
+			.authRole(AuthRole.ROLE_USER)
+			.profileImageUrl(imageUrl)  // S3 URL 저장
+			.agreeMarketing(req.getAgreeMarketing())
+			.agreeMarketingAt(req.getAgreeMarketing() ? LocalDateTime.now() : null)
+			.oauthId(URLDecoder.decode(req.getOauthId(), StandardCharsets.UTF_8))
+			.oauthProvider(URLDecoder.decode(req.getOauthProvider(), StandardCharsets.UTF_8))
+			.userProfile(userProfile)
+			.build();
+
+		userProfile.setUser(user);
+		address.setUser(user);
+
+		Users savedUser = userRepository.save(user);
+
+		// 필수 약관 동의 저장
+		saveUserAgreements(savedUser, req.getAgreedTermsIds());
+
+		// 토큰 생성 및 쿠키 세팅
+		createTokenAndSetCookie(savedUser, response);
+	}
+
+	public void registerPro_photo(SignupRequest.ProSignupRequestDto req,
+		MultipartFile profileImage,
+		HttpServletResponse response) {
+
+		// 프로필 사진 S3 업로드
+		String imageUrl = null;
+		if (profileImage != null && !profileImage.isEmpty()) {
+			Uuid uuid = Uuid.builder().uuid(UUID.randomUUID().toString()).build();
+			String keyName = amazonS3Manager.generateProfilePhotoKeyName(uuid);
+			imageUrl = amazonS3Manager.uploadFile(keyName, profileImage);
+		}
+
+		// 카테고리 조회
+		Category proCategory = categoryRepository.findById(req.getCategoryId())
+			.orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+
+		// ProProfile 생성
+		ProProfile proProfile = ProProfile.builder()
+			.center(req.getCenter())
+			.career(req.getCareer())
+			.category(proCategory)
+			.age(req.getAge())
+			.build();
+
+		// Address 생성
+		SignupRequest.ProSignupRequestDto.AddressRequest addressDto = req.getAddress();
+		Address address = Address.builder()
+			.city(addressDto.getCity())
+			.district(addressDto.getDistrict())
+			.street(addressDto.getStreet())
+			.zipcode(addressDto.getZipcode())
+			.streetCode(addressDto.getStreetCode())
+			.specAddress(addressDto.getSpecAddress())
+			.build();
+
+		// Users 생성 및 연관관계 설정
+		Users user = Users.builder()
+			.username(req.getUsername())
+			.email(req.getEmail())
+			.phone_number(req.getPhoneNum())
+			.address(address)
+			.nickname(req.getNickname())
+			.role(mapToRole(req.getRole()))
+			.gender(mapToGender(req.getGender()))
+			.authRole(AuthRole.ROLE_USER)
+			.profileImageUrl(imageUrl)  // S3 URL 저장
+			.agreeMarketing(req.getAgreeMarketing())
+			.agreeMarketingAt(req.getAgreeMarketing() ? LocalDateTime.now() : null)
+			.oauthId(URLDecoder.decode(req.getOauthId(), StandardCharsets.UTF_8))
+			.oauthProvider(URLDecoder.decode(req.getOauthProvider(), StandardCharsets.UTF_8))
+			.proProfile(proProfile)
+			.build();
+
+		proProfile.setUser(user);
+		address.setUser(user);
+
+		Users savedUser = userRepository.save(user);
+
+		// 필수 약관 동의 저장
+		saveUserAgreements(savedUser, req.getAgreedTermsIds());
+
+		// 토큰 생성 및 쿠키 세팅
+		createTokenAndSetCookie(savedUser, response);
+	}
+
+	private void saveUserAgreements(Users user, List<Long> agreedTermsIds) {
+		if (agreedTermsIds == null || agreedTermsIds.isEmpty())
+			return;
+
+		List<Terms> termsList = termsRepository.findAllById(agreedTermsIds);
+		for (Terms terms : termsList) {
+			UserTermsAgreement agreement = UserTermsAgreement.builder()
+				.user(user)
+				.terms(terms)
+				.agreed(true)
+				.agreedAt(LocalDateTime.now())
+				.build();
+			userTermsAgreementRepository.save(agreement);
+		}
+	}
+
+	private Gender mapToGender(int genderCode) {
+		switch (genderCode) {
+			case 1:
+				return Gender.MALE;
+			case 2:
+				return Gender.FEMALE;
+			default:
+				throw new UserHandler(ErrorStatus.INVALID_GENDER);
+		}
+	}
+
+	private Role mapToRole(int userTypeCode) {
+		switch (userTypeCode) {
+			case 1:
+				return Role.USER;
+			case 2:
+				return Role.PRO;
+			default:
+				throw new UserHandler(ErrorStatus.INVALID_ROLE);
+		}
+	}
+
+	private void createTokenAndSetCookie(Users user, HttpServletResponse response) {
+		String accessToken = jwtTokenProvider.generateToken(user);
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+
+		log.info("JWT 토큰 생성: {}", accessToken);
+
+		user.setRefreshToken(refreshToken);
+		userRepository.save(user);
+
+		// 쿠키 생성
+		Cookie accessCookie = new Cookie("accessToken", accessToken);
+		accessCookie.setHttpOnly(true);
+		accessCookie.setSecure(true);
+		accessCookie.setPath("/");
+		accessCookie.setMaxAge(60 * 30); // 30분
+
+		Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+		refreshCookie.setHttpOnly(true);
+		refreshCookie.setSecure(true);
+		refreshCookie.setPath("/");
+		refreshCookie.setMaxAge(60 * 60 * 24 * 7); // 7일
+
+		response.addCookie(accessCookie);
+		response.addCookie(refreshCookie);
+	}
 
 	// public void registerUser(SignupRequest.UserSignupRequestDto req, HttpServletResponse response) {
 	//
@@ -143,127 +338,4 @@ public class AuthService {
 	//
 	// 	createTokenAndSetCookie(savedUser, response);
 	// }
-
-	private void saveUserAgreements(Users user, List<Long> agreedTermsIds) {
-		if (agreedTermsIds == null || agreedTermsIds.isEmpty())
-			return;
-
-		List<Terms> termsList = termsRepository.findAllById(agreedTermsIds);
-		for (Terms terms : termsList) {
-			UserTermsAgreement agreement = UserTermsAgreement.builder()
-				.user(user)
-				.terms(terms)
-				.agreed(true)
-				.agreedAt(LocalDateTime.now())
-				.build();
-			userTermsAgreementRepository.save(agreement);
-		}
-	}
-
-	private Gender mapToGender(int genderCode) {
-		switch (genderCode) {
-			case 1:
-				return Gender.MALE;
-			case 2:
-				return Gender.FEMALE;
-			default:
-				throw new UserHandler(ErrorStatus.INVALID_GENDER);
-		}
-	}
-
-	private Role mapToRole(int userTypeCode) {
-		switch (userTypeCode) {
-			case 1:
-				return Role.USER;
-			case 2:
-				return Role.PRO;
-			default:
-				throw new UserHandler(ErrorStatus.INVALID_ROLE);
-		}
-	}
-
-	private void createTokenAndSetCookie(Users user, HttpServletResponse response) {
-		String accessToken = jwtTokenProvider.generateToken(user);
-		String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
-
-		log.info("JWT 토큰 생성: {}", accessToken);
-
-		user.setRefreshToken(refreshToken);
-		userRepository.save(user);
-
-		// 쿠키 생성
-		Cookie accessCookie = new Cookie("accessToken", accessToken);
-		accessCookie.setHttpOnly(true);
-		accessCookie.setSecure(true);
-		accessCookie.setPath("/");
-		accessCookie.setMaxAge(60 * 30); // 30분
-
-		Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
-		refreshCookie.setHttpOnly(true);
-		refreshCookie.setSecure(true);
-		refreshCookie.setPath("/");
-		refreshCookie.setMaxAge(60 * 60 * 24 * 7); // 7일
-
-		response.addCookie(accessCookie);
-		response.addCookie(refreshCookie);
-	}
-
-	public void registerUser_photo(SignupRequest.UserSignupRequestDto req,
-		MultipartFile profileImage,
-		HttpServletResponse response) {
-
-		String imageUrl = null;
-		if (profileImage != null && !profileImage.isEmpty()) {
-			Uuid uuid = Uuid.builder().uuid(UUID.randomUUID().toString()).build();
-			String keyName = amazonS3Manager.generateProfilePhotoKeyName(uuid);
-			imageUrl = amazonS3Manager.uploadFile(keyName, profileImage);
-		}
-
-		Users user = Users.builder()
-			.username(req.getUsername())
-			.email(req.getEmail())
-			.phone_number(req.getPhoneNum())
-			.nickname(req.getNickname())
-			.role(mapToRole(req.getRole()))
-			.authRole(AuthRole.ROLE_USER)
-			.profileImageUrl(imageUrl)  // S3 URL 저장
-			.agreeMarketing(req.getAgreeMarketing())
-			.agreeMarketingAt(req.getAgreeMarketing() ? LocalDateTime.now() : null)
-			.oauthId(URLDecoder.decode(req.getOauthId(), StandardCharsets.UTF_8))
-			.oauthProvider(URLDecoder.decode(req.getOauthProvider(), StandardCharsets.UTF_8))
-			.build();
-
-		userRepository.save(user);
-		createTokenAndSetCookie(user, response);
-	}
-
-	public void registerPro_photo(SignupRequest.ProSignupRequestDto req,
-		MultipartFile profileImage,
-		HttpServletResponse response) {
-
-		String imageUrl = null;
-		if (profileImage != null && !profileImage.isEmpty()) {
-			Uuid uuid = Uuid.builder().uuid(UUID.randomUUID().toString()).build();
-			String keyName = amazonS3Manager.generateProfilePhotoKeyName(uuid);
-			imageUrl = amazonS3Manager.uploadFile(keyName, profileImage);
-		}
-
-		Users user = Users.builder()
-			.username(req.getUsername())
-			.email(req.getEmail())
-			.phone_number(req.getPhoneNum())
-			.nickname(req.getNickname())
-			.role(mapToRole(req.getRole()))
-			.gender(mapToGender(req.getGender()))
-			.authRole(AuthRole.ROLE_USER)
-			.profileImageUrl(imageUrl)
-			.agreeMarketing(req.getAgreeMarketing())
-			.agreeMarketingAt(req.getAgreeMarketing() ? LocalDateTime.now() : null)
-			.oauthId(URLDecoder.decode(req.getOauthId(), StandardCharsets.UTF_8))
-			.oauthProvider(URLDecoder.decode(req.getOauthProvider(), StandardCharsets.UTF_8))
-			.build();
-
-		userRepository.save(user);
-		createTokenAndSetCookie(user, response);
-	}
 }

--- a/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
+++ b/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
@@ -2,8 +2,6 @@ package com.grabpt.service.MatchingService;
 
 import java.time.LocalDateTime;
 
-import com.grabpt.domain.entity.Contract;
-import com.grabpt.service.ContractService.ContractService;
 import org.springframework.stereotype.Service;
 
 import com.grabpt.apiPayload.code.status.ErrorStatus;
@@ -17,6 +15,7 @@ import com.grabpt.domain.enums.RequestStatus;
 import com.grabpt.repository.MatchingRepository.MatchingRepository;
 import com.grabpt.repository.RequestionRepository.RequestionRepository;
 import com.grabpt.repository.SuggestionRepository.SuggestionRepository;
+import com.grabpt.service.ContractService.ContractService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -48,7 +47,7 @@ public class MatchingServiceImpl implements MatchingService {
 			.suggestion(suggestion)
 			.agreedPrice(suggestion.getPrice())
 			.matchedAt(LocalDateTime.now())
-			.status(MatchingStatus.WAITING)  //대기중으로 변경
+			.status(MatchingStatus.MATCHED)  //대기중으로 변경
 			.build();
 
 		// 요청서 상태 변경
@@ -56,7 +55,7 @@ public class MatchingServiceImpl implements MatchingService {
 
 		matchingRepository.save(matching);
 		requestionRepository.save(requestion); // 상태 저장 반영
-		contractService.createContract(matching,requestion,suggestion);
+		contractService.createContract(matching, requestion, suggestion);
 
 		return matching;
 

--- a/src/main/java/com/grabpt/service/OrderService/OrderService.java
+++ b/src/main/java/com/grabpt/service/OrderService/OrderService.java
@@ -7,6 +7,6 @@ public interface OrderService {
 	// 주문 정보 저장 (사용자 정보와 프론트에서 제공해준 Payment를 입력받는다)
 	Order order(Users users);
 
-	Order customOrder(Users user, Long price, String itemName);
+	Order customOrder(Users user, Long price, String itemName, Long matchingId);
 
 }

--- a/src/main/java/com/grabpt/service/OrderService/OrderServiceImpl.java
+++ b/src/main/java/com/grabpt/service/OrderService/OrderServiceImpl.java
@@ -5,10 +5,12 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.grabpt.domain.entity.Matching;
 import com.grabpt.domain.entity.Order;
 import com.grabpt.domain.entity.Payment;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.PaymentStatus;
+import com.grabpt.repository.MatchingRepository.MatchingRepository;
 import com.grabpt.repository.OrderRepository.OrderRepository;
 import com.grabpt.repository.PaymentRepository.PaymentRepository;
 
@@ -21,6 +23,7 @@ public class OrderServiceImpl implements OrderService {
 
 	private final OrderRepository orderRepository;
 	private final PaymentRepository paymentRepository;
+	private final MatchingRepository matchingRepository;
 
 	@Override
 	public Order order(Users users) {
@@ -45,7 +48,12 @@ public class OrderServiceImpl implements OrderService {
 	}
 
 	@Override
-	public Order customOrder(Users user, Long price, String itemName) {
+	public Order customOrder(Users user, Long price, String itemName, Long matchingId) {
+
+		// 매칭 조회
+		Matching matching = matchingRepository.findById(matchingId)
+			.orElseThrow(() -> new IllegalArgumentException("Matching not found with id: " + matchingId));
+
 		// 결제내역 생성
 		Payment payment = Payment.builder()
 			.price(price)
@@ -61,6 +69,7 @@ public class OrderServiceImpl implements OrderService {
 			.itemName(itemName)
 			.orderUid(UUID.randomUUID().toString())
 			.payment(payment)
+			.matching(matching)
 			.build();
 
 		return orderRepository.save(order);

--- a/src/main/java/com/grabpt/service/SettlementService/SettlementServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SettlementService/SettlementServiceImpl.java
@@ -3,7 +3,6 @@ package com.grabpt.service.SettlementService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.grabpt.domain.enums.MatchingStatus;
@@ -28,9 +27,9 @@ public class SettlementServiceImpl implements SettlementService {
 	public TrainerDashboardDto getTrainerDashboard(Long proProfileId, int page, int size) {
 		Long totalEarnings = orderRepository.getTrainerTotalEarnings(proProfileId, PaymentStatus.OK);
 		Long totalOrders = orderRepository.getTrainerTotalOrders(proProfileId, PaymentStatus.OK);
-		Long activeClients = matchingRepository.getActiveClients(proProfileId, MatchingStatus.MATCHED);
+		Long activeClients = matchingRepository.getActiveClients(proProfileId, MatchingStatus.COMPLETED);
 
-		Pageable pageable = PageRequest.of(page, size, Sort.by("paymentDate").descending());
+		Pageable pageable = PageRequest.of(page, size);
 		Page<MemberPaymentDto> memberPayments
 			= orderRepository.getMemberPayments(proProfileId, PaymentStatus.OK, pageable);
 


### PR DESCRIPTION
## PR 제목
- [Feat] 정산 로직 수정 및 프로필사진 저장 로직 수정

## 변경 사항
- 정산 로직 수정
- 프로필사진 저장 서비스 코드 수정

## 작업 내용 체크
- MatchingStatus.Matched로 조회하도록 변경
- PaymentStatus.OK로 조회하도록 변경
- customOrder(Users user, Long price, String itemName, Long matchingId)로 matchingId를 매개변수로 받아 DB에 저장하도록 변경
- 프로필사진 저장 시 약관동의, 프로필 연관관계 설정 이슈 고침
- API 요청 URL은 /api로 시작하도록 변경

## 관련 이슈
- 

## 기타 공유 사항
- 
