### PR TITLE
[Fix] 메시지 조회 API 커서 기반으로 변경

### DIFF
--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -77,13 +77,21 @@ public class ChatController {
 	}
 
 	@Operation(
-		description = "채팅방의 모든 메시지를 조회합니다. roomId를 pathVariable로 전달받습니다",
-		summary = "채팅방의 모든 메시지 조회 API"
+		description = "채팅방의 최근 메시지를 20개 조회합니다. roomId를 pathVariable로 전달받고, cursor id를 requestParam으로 받습니다",
+		summary = "채팅방의 메시지 20개 조회 API (cursor기반 기본값 0)"
 	)
 	@GetMapping("/chatRoom/{roomId}/messages")
 	@ResponseBody
-	public ApiResponse<List<ChatResponse.MessageResponseDto>> getMessagesByChatRoom(@PathVariable(name = "roomId") Long roomId){
-		return ApiResponse.onSuccess(chatService.getMessagesByChatRoom(roomId));
+	public ApiResponse<ChatResponse.MessageResponseByCursorDto> getMessagesByChatRoom(@PathVariable(name = "roomId") Long roomId,
+																					  @RequestParam(name = "cursor", required = false, defaultValue = "0") long cursor){
+		List<ChatResponse.MessageResponseDto> messageResponseDto = chatService.getMessagesByChatRoom(roomId, cursor);
+
+		ChatResponse.MessageResponseByCursorDto messageResponseByCursorDto = ChatResponse.MessageResponseByCursorDto.builder()
+			.cursor(messageResponseDto.get(messageResponseDto.size()-1).getMessageId())
+			.messages(messageResponseDto)
+			.build();
+
+		return ApiResponse.onSuccess(messageResponseByCursorDto);
 	}
 
 	@Operation(

--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -86,8 +86,13 @@ public class ChatController {
 																					  @RequestParam(name = "cursor", required = false, defaultValue = "0") long cursor){
 		List<ChatResponse.MessageResponseDto> messageResponseDto = chatService.getMessagesByChatRoom(roomId, cursor);
 
+		long newCursor = 0;
+		if (!messageResponseDto.isEmpty()) {
+			newCursor = messageResponseDto.get(messageResponseDto.size() - 1).getMessageId();
+		}
+
 		ChatResponse.MessageResponseByCursorDto messageResponseByCursorDto = ChatResponse.MessageResponseByCursorDto.builder()
-			.cursor(messageResponseDto.get(messageResponseDto.size()-1).getMessageId())
+			.cursor(newCursor)
 			.messages(messageResponseDto)
 			.build();
 
@@ -104,6 +109,16 @@ public class ChatController {
 																			  HttpServletRequest request) throws IllegalAccessException {
 		Long userId = userQueryService.getUserId(request);
 		return ApiResponse.onSuccess(chatService.getChatRoomList(userId, keyword));
+	}
+	@Operation(
+		summary = "유저의 전체 안읽은 메시지 개수 조회"
+	)
+	@GetMapping("chat/unreadCount")
+	@ResponseBody
+	public ApiResponse<Long> getUnreadCount(HttpServletRequest request) throws IllegalAccessException {
+		Long userId = userQueryService.getUserId(request);
+		Long allUnreadMessageCount = chatService.getAllUnreadMessageCount(userId);
+		return ApiResponse.onSuccess(allUnreadMessageCount);
 	}
 
 	@GetMapping("/chat-test")

--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -108,7 +108,6 @@ public class ChatController {
 
 	@GetMapping("/chat-test")
 	public String chatTest(HttpServletRequest request) throws IllegalAccessException {
-		String email = userQueryService.getUserInfo(request).getEmail();
 		return "chat-test";
 	}
 }

--- a/src/main/java/com/grabpt/domain/entity/UserChatRoom.java
+++ b/src/main/java/com/grabpt/domain/entity/UserChatRoom.java
@@ -40,6 +40,7 @@ public class UserChatRoom extends BaseEntity {
 	@JoinColumn(name = "other_user_id", nullable = false)
 	private Users otherUser;
 
+	private Long unreadCount;
 	private String roomName;
 	private Long lastReadMessageId; // 마지막으로 읽은 메시지 ID 저장
 	private LocalDateTime lastReadAt;

--- a/src/main/java/com/grabpt/dto/response/ChatResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ChatResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ChatResponse {
 	@AllArgsConstructor
@@ -20,6 +21,16 @@ public class ChatResponse {
 		@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 		LocalDateTime sendAt;
 		Integer readCount;
+	}
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	@Getter
+	@Builder
+	public static class MessageResponseByCursorDto{
+		List<MessageResponseDto> messages;
+		Long cursor;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
@@ -1,6 +1,7 @@
 package com.grabpt.repository.ChatRepository;
 
 import com.grabpt.domain.entity.Messages;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,8 +10,12 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Messages, Long> {
-	@Query("SELECT m FROM Messages m WHERE m.chatRoom.id = :roomId")
-	List<Messages> findAllByChatRoom(@Param("roomId") Long roomId);
+	@Query("""
+	SELECT m FROM Messages m WHERE m.chatRoom.id = :roomId
+	AND (:cursor = 0 OR m.id < :cursor)
+	ORDER BY m.id DESC
+	""")
+	List<Messages> findMessagesByCursor(@Param("roomId") Long roomId, @Param("cursor") Long cursor, Pageable pageable);
 
 	Optional<Messages> findTopByChatRoom_IdOrderByIdDesc(Long roomId); //가장 최근 메시지
 
@@ -24,9 +29,7 @@ public interface MessageRepository extends JpaRepository<Messages, Long> {
     AND m.id > :lastReadMessageId
     """)
 	Long countByRoomIdAndIdGreaterThan(
-		@Param("roomId") Long roomId,
-		@Param("lastReadMessageId") Long lastReadMessageId
-	);
+		@Param("roomId") Long roomId, @Param("lastReadMessageId") Long lastReadMessageId);
 
 	@Query("SELECT m FROM Messages m WHERE m.chatRoom.id = :roomId AND m.readCount = 1 AND m.sender.id <> :userId")
 	List<Messages> findUnreadMessages(@Param("roomId") Long roomId, @Param("userId") Long userId);

--- a/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface MessageRepository extends JpaRepository<Messages, Long> {
 	@Query("""
@@ -35,18 +37,28 @@ public interface MessageRepository extends JpaRepository<Messages, Long> {
 	List<Messages> findUnreadMessages(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
 	@Query("""
-    SELECT COUNT(m) FROM Messages m
-    JOIN m.chatRoom r
-    WHERE r.id = :roomId
-    AND m.id > (
-         SELECT COALESCE(ucr.lastReadMessageId, 0)
-		 FROM UserChatRoom ucr
-		 WHERE ucr.chatRoom.id = :roomId AND ucr.user.id = :userId
-    )
-    AND m.sender.id <> :userId
+    SELECT m.chatRoom.id, COUNT(m)
+       FROM Messages m
+       JOIN m.chatRoom r
+       WHERE r.id IN :roomIds
+       AND m.id > (
+            SELECT COALESCE(ucr.lastReadMessageId, 0)
+            FROM UserChatRoom ucr
+            WHERE ucr.chatRoom.id = m.chatRoom.id AND ucr.user.id = :userId
+       )
+       AND m.sender.id <> :userId
+       GROUP BY m.chatRoom.id
 	""")
-	Long countUnreadMessages(@Param("roomId") Long roomId, @Param("userId") Long userId);
+	List<Object[]> countUnreadMessages(@Param("roomIds") List<Long> roomIds, @Param("userId") Long userId);
 
+	default Map<Long, Long> getUnreadCountMap(List<Long> roomIds, Long userId) {
+		List<Object[]> results = countUnreadMessages(roomIds, userId);
+		return results.stream()
+			.collect(Collectors.toMap(
+				result -> (Long) result[0],  // roomId
+				result -> (Long) result[1]   // count
+			));
+	}
 }
 
 

--- a/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
@@ -13,7 +13,7 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
 	Optional<UserChatRoom> findChatRoomByUserPair(@Param("userId") Long userId, @Param("proId") Long proId);
 
 	@Query("""
-    SELECT ucr FROM UserChatRoom ucr
+    SELECT DISTINCT ucr FROM UserChatRoom ucr
     JOIN FETCH ucr.chatRoom cr
     JOIN FETCH ucr.user u
     JOIN FETCH ucr.otherUser ou

--- a/src/main/java/com/grabpt/service/ChatService/ChatService.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatService.java
@@ -10,7 +10,7 @@ public interface ChatService {
 	//public Messages saveMessage(Long roomId, MessageRequest.messageRequestDto request);
 	public ChatResponse.CreateChatRoomResponseDto getOrcreateChatRoom(ChatRequest.CreateChatRoomRequestDto request);
 	public Messages createChatMessage(ChatRequest.MessageRequestDto request);
-	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId);
+	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor);
 	public List<ChatResponse.ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword);
 	public Long getLastReadMessageId(Long roomId, Long userId);
 	public Long getUnreadMessageCount(Long roomId, Long userId);

--- a/src/main/java/com/grabpt/service/ChatService/ChatService.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatService.java
@@ -5,6 +5,7 @@ import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ChatService {
 	//public Messages saveMessage(Long roomId, MessageRequest.messageRequestDto request);
@@ -12,8 +13,7 @@ public interface ChatService {
 	public Messages createChatMessage(ChatRequest.MessageRequestDto request);
 	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor);
 	public List<ChatResponse.ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword);
-	public Long getLastReadMessageId(Long roomId, Long userId);
-	public Long getUnreadMessageCount(Long roomId, Long userId);
+	public Map<Long, Long> getUnreadMessageCount(List<Long> roomIds, Long userId);
 	public void updateLastReadMessageWhenExist(Long roomId, Long userId);
 	public void updateLastReadMessageWhenEnter(Long roomId, Long userId);
 

--- a/src/main/java/com/grabpt/service/ChatService/ChatService.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatService.java
@@ -13,6 +13,7 @@ public interface ChatService {
 	public Messages createChatMessage(ChatRequest.MessageRequestDto request);
 	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor);
 	public List<ChatResponse.ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword);
+	public Long getAllUnreadMessageCount(Long userId);
 	public Map<Long, Long> getUnreadMessageCount(List<Long> roomIds, Long userId);
 	public void updateLastReadMessageWhenExist(Long roomId, Long userId);
 	public void updateLastReadMessageWhenEnter(Long roomId, Long userId);

--- a/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
@@ -13,6 +13,9 @@ import com.grabpt.repository.ChatRepository.UserChatRoomRepository;
 import com.grabpt.repository.UserRepository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,8 +100,13 @@ public class ChatServiceImpl implements ChatService{
 	}
 
 	@Override
-	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId) {
-		List<Messages> messagesByChatRoom = messageRepository.findAllByChatRoom(roomId);
+	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor) {
+		if(cursor == null){
+			cursor = 0L;
+		}
+		Pageable pageable = PageRequest.of(0, 20);
+
+		List<Messages> messagesByChatRoom = messageRepository.findMessagesByCursor(roomId, cursor, pageable);
 		List<ChatResponse.MessageResponseDto> messageResponseDto = messagesByChatRoom.stream().map(
 			message-> ChatConverter.toMessageResponseDto(message)).collect(Collectors.toList());
 		return messageResponseDto;

--- a/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
@@ -21,10 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -119,28 +116,24 @@ public class ChatServiceImpl implements ChatService{
 
 		List<UserChatRoom> chatRooms = userChatRoomRepository.findByUserId(userId, keyword);
 
+		List<Long> roomIds = chatRooms.stream()
+			.map(chatRoom -> chatRoom.getChatRoom().getId())
+			.toList();
+		Map<Long, Long> unreadMessageCount = getUnreadMessageCount(roomIds, userId);
+
 		return chatRooms.stream()
 			.map(chatRoom -> {
-				Long unreadCount = getUnreadMessageCount(chatRoom.getChatRoom().getId(), userId);
-				return ChatConverter.toChatRoomPreviewDto(chatRoom, unreadCount);
+				Long roomId = chatRoom.getChatRoom().getId();
+				Long unreadCount = unreadMessageCount.getOrDefault(roomId, 0L);				return ChatConverter.toChatRoomPreviewDto(chatRoom, unreadCount);
 			})
 			.toList();
-	}
-
-	//Message Count 관련
-	//채팅방에서 유저가 마지막으로 읽은 메시지의 아이디 가져옴
-	@Override
-	public Long getLastReadMessageId(Long roomId, Long userId){
-		UserChatRoom chatRoom = userChatRoomRepository.findByRoomIdAndUserId(roomId, userId).orElseThrow(
-			() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_FOUND));
-		return chatRoom.getLastReadMessageId();
 	}
 
 
 	//상대가 보낸 메시지중 lastReadMessageId보다 큰 메시지 수
 	@Override
-	public Long getUnreadMessageCount(Long roomId, Long userId){
-		return messageRepository.countUnreadMessages(roomId, userId);
+	public Map<Long, Long> getUnreadMessageCount(List<Long> roomIds, Long userId){
+		return messageRepository.getUnreadCountMap(roomIds, userId);
 	}
 
 	//채팅방 접속상태에서 message 읽은 경우

--- a/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatServiceImpl.java
@@ -124,7 +124,8 @@ public class ChatServiceImpl implements ChatService{
 		return chatRooms.stream()
 			.map(chatRoom -> {
 				Long roomId = chatRoom.getChatRoom().getId();
-				Long unreadCount = unreadMessageCount.getOrDefault(roomId, 0L);				return ChatConverter.toChatRoomPreviewDto(chatRoom, unreadCount);
+				Long unreadCount = unreadMessageCount.getOrDefault(roomId, 0L);
+				return ChatConverter.toChatRoomPreviewDto(chatRoom, unreadCount);
 			})
 			.toList();
 	}
@@ -135,6 +136,21 @@ public class ChatServiceImpl implements ChatService{
 	public Map<Long, Long> getUnreadMessageCount(List<Long> roomIds, Long userId){
 		return messageRepository.getUnreadCountMap(roomIds, userId);
 	}
+
+	@Override
+	public Long getAllUnreadMessageCount(Long userId){
+		Users user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+		List<UserChatRoom> chatRooms = userChatRoomRepository.findByUserId(userId, null);
+
+		List<Long> roomIds = chatRooms.stream()
+			.map(chatRoom -> chatRoom.getChatRoom().getId())
+			.toList();
+		Map<Long, Long> unreadMessageCount = getUnreadMessageCount(roomIds, userId);
+		return unreadMessageCount.values().stream().mapToLong(Long::longValue).sum();
+	}
+
 
 	//채팅방 접속상태에서 message 읽은 경우
 	@Override

--- a/src/main/resources/templates/chat-test.html
+++ b/src/main/resources/templates/chat-test.html
@@ -222,10 +222,11 @@
 </div>
 
 <script>
-    let stompClient = null;
-    let subscription = null;       // 현재 채팅방 구독 객체
+    let currentCursor = 0; // 전역 변수로 커서 관리
     let currentRoomId = null;
-    let senderId = null;           // 내 유저 아이디
+    let senderId = null;
+    let stompClient = null;
+    let subscription = null;
     let readStatusSubscription = null;
 
 // 읽음 상태 업데이트 전달 받음
@@ -366,8 +367,7 @@
         }
         subscription = stompClient.subscribe(`/subscribe/chat/${roomId}`, (msg) => {
             const body = JSON.parse(msg.body);
-            appendMessage(body.senderId, body.content, body.sendAt, body.messageType, body.readCount, body.messageId);
-
+            appendMessage(body);
             // 내가 보낸 메시지가 아니고 현재 보고 있는 방이라면 실시간 단건 읽음 처리
             if (body.senderId !== senderId && currentRoomId === roomId) {
                 markLastReadWhen2(roomId);
@@ -419,15 +419,20 @@
     await markLastReadWhen1(roomId);
 
     // 메시지 로드
-    const res = await fetch(`/chatRoom/${roomId}/messages`);
+    const res = await fetch(`/chatRoom/${roomId}/messages?cursor=0`);
     const result = await res.json();
-    if (result.isSuccess) {
-        const messages = result.result;
-        messages.forEach(msg => appendMessage(msg.senderId, msg.content, msg.sendAt, msg.messageType, msg.readCount, msg.id));
-    } else {
-        alert("메시지를 불러오지 못했습니다.");
-        return;
-    }
+        if (result.isSuccess) {
+            const responseData = result.result;
+            const messages = responseData.messages;
+            currentCursor = responseData.cursor;
+
+            // 메시지 리스트를 하나씩 appendMessage 호출로 추가
+            messages.sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
+            messages.forEach(msg => appendMessage(msg));
+        } else {
+            alert("메시지를 불러오지 못했습니다.");
+            return;
+        }
 
     // 웹소켓 연결 및 구독 시작
     await connectWebSocket();
@@ -455,63 +460,73 @@
         input.value = '';
     }
 
-  function appendMessage(sender, content, sendAt, messageType = "TEXT", readCount = null, messageId) {
-    const log = document.getElementById("chat-log");
-    const div = document.createElement("div");
+    function appendMessage(message) {
+        const log = document.getElementById("chat-log");
+        if (!log) return;
 
-    if(messageId){
-        div.setAttribute("data-message-id", messageId);
-    }
+        const div = document.createElement("div");
 
-    const isMine = sender === senderId;
-    const time = sendAt ? formatMsgTime(sendAt) : "";
-
-    div.className = isMine ? "mine" : "other";
-    const bubble = document.createElement("span");
-    bubble.className = "bubble";
-
-    if (messageType === "IMAGE" && content) {
-        bubble.innerHTML = `<img src="${content}" style="max-width:170px;max-height:128px;border-radius:7px;">`;
-    } else if (messageType === "FILE" && content) {
-        bubble.innerHTML = `파일을 보냈습니다. <a href="${content}" target="_blank" download>다운로드</a>`;
-    } else {
-        bubble.textContent = content || "";
-    }
-
-    const timeEl = document.createElement("span");
-    timeEl.className = "msg-time";
-    timeEl.textContent = time;
-
-    const readCountEl = document.createElement("span");
-    readCountEl.className = "msg-read-count";
-    readCountEl.style.marginLeft = "8px";
-    readCountEl.style.fontSize = "11px";
-
-    if (isMine) {
-        if (readCount !== null) {
-            if (readCount === 0) {
-                readCountEl.textContent = "✔ 모두 읽음";
-                readCountEl.style.color = "#4CAF50";
-            } else {
-                readCountEl.textContent = `👁️ ${readCount}명 미확인`;
-                readCountEl.style.color = "#d33";
-            }
+        if (message.messageId !== undefined) {
+            div.setAttribute("data-message-id", message.messageId);
         }
-    } else {
-        readCountEl.textContent = "";
-    }
 
-    if (isMine) {
-        div.appendChild(timeEl);
-        div.appendChild(readCountEl);
-        div.appendChild(bubble);
-    } else {
-        div.appendChild(bubble);
-        div.appendChild(timeEl);
+        const isMine = message.senderId === senderId;
+        const time = message.sendAt ? formatMsgTime(message.sendAt) : "";
+
+        div.className = isMine ? "mine" : "other";
+
+        const bubble = document.createElement("span");
+        bubble.className = "bubble";
+
+        switch (message.messageType) {
+            case "IMAGE":
+                bubble.innerHTML = message.content ?
+                    `<img src="${message.content}" style="max-width:170px;max-height:128px;border-radius:7px;">`
+                    : "(이미지 없음)";
+                break;
+            case "FILE":
+                bubble.innerHTML = message.content ?
+                    `파일을 보냈습니다. <a href="${message.content}" target="_blank" download>다운로드</a>`
+                    : "(파일 없음)";
+                break;
+            default:
+                bubble.textContent = message.content || "";
+        }
+
+        const timeEl = document.createElement("span");
+        timeEl.className = "msg-time";
+        timeEl.textContent = time;
+
+        const readCountEl = document.createElement("span");
+        readCountEl.className = "msg-read-count";
+        readCountEl.style.marginLeft = "8px";
+        readCountEl.style.fontSize = "11px";
+
+        if (isMine) {
+            if (message.readCount !== null && message.readCount !== undefined) {
+                if (message.readCount === 0) {
+                    readCountEl.textContent = "✔ 모두 읽음";
+                    readCountEl.style.color = "#4CAF50";
+                } else {
+                    readCountEl.textContent = `👁️ ${message.readCount}명 미확인`;
+                    readCountEl.style.color = "#d33";
+                }
+            }
+        } else {
+            readCountEl.textContent = "";
+        }
+
+        if (isMine) {
+            div.appendChild(timeEl);
+            div.appendChild(readCountEl);
+            div.appendChild(bubble);
+        } else {
+            div.appendChild(bubble);
+            div.appendChild(timeEl);
+        }
+        log.appendChild(div);
+        log.scrollTop = log.scrollHeight;
     }
-    log.appendChild(div);
-    log.scrollTop = log.scrollHeight;
-}
 
 
     // 9) 시간 포맷 함수 (기존 그대로)
@@ -529,7 +544,25 @@
             return `${dt.getMonth()+1}/${dt.getDate()}`;
         }
     }
+    async function loadMoreMessages() {
+        if (!currentRoomId) return;
 
+        const res = await fetch(`/chatRoom/${currentRoomId}/messages?cursor=${currentCursor}`);
+        const result = await res.json();
+
+        if (result.isSuccess) {
+            const responseData = result.result;
+            const messages = responseData.messages;
+            const newCursor = responseData.cursor;
+
+            if (messages.length === 0) return; // 더 이상 메시지 없음
+
+            // 이전 메시지는 위쪽에 붙이려면 prepend 기능 추가 필요 (별도 구현 추천)
+            messages.forEach(msg => appendMessage(msg));  // 현재는 아래쪽 append, 필요시 개선
+
+            currentCursor = newCursor;
+        }
+    }
     // 11) 초기 로드 시 채팅방 목록 불러오기
     window.addEventListener("DOMContentLoaded", () => {
         loadChatRooms();


### PR DESCRIPTION
## PR 제목
- [Fix] 메시지 조회 API 커서 기반으로 변경

## 변경 사항
- 메시지 조회시 모든 메시지가 아닌 cursor기반으로 20개씩 조회

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #17 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
