### PR TITLE
[Feat] 알림 전송 로직 구현(제안서만) 및 알림 리스트 API 구현

### DIFF
--- a/src/main/java/com/grabpt/controller/AlarmController.java
+++ b/src/main/java/com/grabpt/controller/AlarmController.java
@@ -1,0 +1,32 @@
+package com.grabpt.controller;
+
+import com.grabpt.apiPayload.ApiResponse;
+import com.grabpt.converter.AlarmConverter;
+import com.grabpt.domain.entity.Alarm;
+import com.grabpt.dto.response.AlarmResponseDto;
+import com.grabpt.repository.AlarmRepository.AlarmRepository;
+import com.grabpt.service.UserService.UserQueryService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/alarm")
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+
+	private final UserQueryService userQueryService;
+	private final AlarmRepository alarmRepository;
+
+	@GetMapping
+	public ApiResponse<List<AlarmResponseDto>> getAlarmList(HttpServletRequest request) throws IllegalAccessException {
+		Long userId = userQueryService.getUserId(request);
+		List<Alarm> alarmList = alarmRepository.findAllByUserId(userId);
+		List<AlarmResponseDto> list = alarmList.stream().map(AlarmConverter::toAlarmResponseDto).toList();
+		return ApiResponse.onSuccess(list);
+	}
+}

--- a/src/main/java/com/grabpt/converter/AlarmConverter.java
+++ b/src/main/java/com/grabpt/converter/AlarmConverter.java
@@ -1,0 +1,20 @@
+package com.grabpt.converter;
+
+import com.grabpt.domain.entity.Alarm;
+import com.grabpt.dto.response.AlarmResponseDto;
+
+import java.time.LocalDateTime;
+
+public class AlarmConverter {
+	public static AlarmResponseDto toAlarmResponseDto(Alarm alarm){
+		return AlarmResponseDto.builder()
+			.id(alarm.getId())
+			.type(alarm.getType())
+			.title(alarm.getTitle())
+			.content(alarm.getContent())
+			.createdAt(LocalDateTime.now())
+			.redirectUrl(alarm.getRedirectUrl())
+			.isRead(alarm.isRead())
+			.build();
+	}
+}

--- a/src/main/java/com/grabpt/domain/entity/Alarm.java
+++ b/src/main/java/com/grabpt/domain/entity/Alarm.java
@@ -1,0 +1,31 @@
+package com.grabpt.domain.entity;
+
+import com.grabpt.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.cglib.core.Local;
+
+@Entity
+@Getter
+@Setter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Alarm extends BaseEntity {
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private Users user;
+
+	private String type;
+	private String title;
+	private String content;
+	private String redirectUrl;
+	private boolean isRead;
+}

--- a/src/main/java/com/grabpt/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/grabpt/dto/response/AlarmResponseDto.java
@@ -1,0 +1,22 @@
+package com.grabpt.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlarmResponseDto {
+	Long id;
+	String type;
+	String title;
+	String content;
+	String redirectUrl;
+	LocalDateTime createdAt;
+	boolean isRead;
+}

--- a/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
+++ b/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
@@ -1,0 +1,12 @@
+package com.grabpt.repository.AlarmRepository;
+
+import com.grabpt.domain.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+	@Query("SELECT a FROM Alarm a WHERE a.user.id = :userId")
+	List<Alarm> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/grabpt/service/AlarmService/AlarmService.java
+++ b/src/main/java/com/grabpt/service/AlarmService/AlarmService.java
@@ -1,0 +1,5 @@
+package com.grabpt.service.AlarmService;
+
+public interface AlarmService {
+	public void sendAlarm(Long userId, String type, String title, String message, String redirectUrl);
+}

--- a/src/main/java/com/grabpt/service/AlarmService/AlarmServiceImpl.java
+++ b/src/main/java/com/grabpt/service/AlarmService/AlarmServiceImpl.java
@@ -1,0 +1,42 @@
+package com.grabpt.service.AlarmService;
+
+import com.grabpt.apiPayload.code.status.ErrorStatus;
+import com.grabpt.apiPayload.exception.handler.UserHandler;
+import com.grabpt.converter.AlarmConverter;
+import com.grabpt.domain.entity.Alarm;
+import com.grabpt.domain.entity.Users;
+import com.grabpt.repository.AlarmRepository.AlarmRepository;
+import com.grabpt.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlarmServiceImpl implements AlarmService {
+
+	private final UserRepository userRepository;
+	private final SimpMessagingTemplate messagingTemplate;
+	private final AlarmRepository alarmRepository;
+
+	@Transactional
+	public void sendAlarm(Long userId, String type, String title, String content, String redirectUrl) {
+
+		Users user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+		Alarm alarm = Alarm.builder()
+			.user(user)
+			.isRead(false)
+			.type(type)
+			.title(title)
+			.content(content)
+			.redirectUrl(redirectUrl)
+			.build();
+		alarmRepository.save(alarm);
+		messagingTemplate.convertAndSend("/user/" + user.getId() + "/alarm", AlarmConverter.toAlarmResponseDto(alarm));
+		log.info("Alarm sent to user: {}", user.getId());
+	}
+}

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.grabpt.service.AlarmService.AlarmService;
+import com.grabpt.service.AlarmService.AlarmServiceImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -42,6 +44,7 @@ public class SuggestionServiceImpl implements SuggestionService {
 	private final ProProfileRepository proProfileRepository;
 	private final RequestionRepository requestionRepository;
 	private final UserQueryService userQueryService;
+	private final AlarmService alarmService;
 
 	@Override
 	public Suggestions save(SuggestionRequestDto dto, String email) {
@@ -65,8 +68,10 @@ public class SuggestionServiceImpl implements SuggestionService {
 
 		suggestion.setProProfile(proProfile);   // 연관관계 설정
 		suggestion.setRequestion(requestion);   // 연관관계 설정
-
-		return suggestionRepository.save(suggestion);
+		suggestion = suggestionRepository.save(suggestion);
+		alarmService.sendAlarm(requestion.getUser().getId(), "SUGGESTION", "제안서 도착",
+			user.getNickname()+" 님이 제안서를 보냈습니다", "/api/suggestion/"+suggestion.getId());
+		return suggestion;
 	}
 
 	@Override


### PR DESCRIPTION
## PR 제목
- [Feat] 알림 전송 로직 구현(제안서만) 및 알림 리스트 API 구현

## 변경 사항
- Alarm 엔티티, 서비스, 컨트롤러, 컨버터, dto 생성
- SuggestionService에서 제안서 저장 시 상대방에게 알람 전송하도록 수정

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #113 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
