### PR TITLE
[Fix] 알림 리스트 조회 시 읽지 않은 것들만 조회

### DIFF
--- a/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
+++ b/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-	@Query("SELECT a FROM Alarm a WHERE a.user.id = :userId AND a.isRead")
+	@Query("SELECT a FROM Alarm a WHERE a.user.id = :userId AND a.isRead = false")
 	List<Alarm> findAllUnReadAlarmByUserId(Long userId); //읽지 않은 것들만 조회
 }

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -91,9 +91,10 @@ public class SuggestionServiceImpl implements SuggestionService {
 				suggestion.addPhoto(suggestionPhoto); // 양방향 연관관계 처리
 			}
 		}
+		Suggestions save = suggestionRepository.save(suggestion);
 		alarmService.sendAlarm(requestion.getUser().getId(), "SUGGESTION", "제안서 도착",
 			user.getNickname()+" 님이 제안서를 보냈습니다", "/api/suggestion/"+suggestion.getId());
-		return suggestionRepository.save(suggestion);
+		return save;
 	}
 
 	@Override


### PR DESCRIPTION
## PR 제목
- [Fix] 알림 리스트 조회 시 읽지 않은 것들만 조회

## 변경 사항
- SuggestionServiceImpl 제안서 저장 후 알람 보내도록 수정
- AlarmRepository 알림 리스트 조회 로직 수정

## 관련 이슈
- 관련 이슈 번호: #113 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
