### PR TITLE
[Feat] 알림 읽을 시에도 안읽은 알림 개수 웹소켓으로 전달

### DIFF
--- a/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
+++ b/src/main/java/com/grabpt/repository/AlarmRepository/AlarmRepository.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 	@Query("SELECT a FROM Alarm a WHERE a.user.id = :userId AND a.isRead = false")
 	List<Alarm> findAllUnReadAlarmByUserId(Long userId); //읽지 않은 것들만 조회
+
+	@Query("SELECT COUNT(a) FROM Alarm a WHERE a.user.id = :userId AND a.isRead = false")
+	Long countUnReadAlarmByUserId(Long userId);
 }

--- a/src/main/java/com/grabpt/service/AlarmService/AlarmService.java
+++ b/src/main/java/com/grabpt/service/AlarmService/AlarmService.java
@@ -12,4 +12,6 @@ public interface AlarmService {
 	public AlarmResponseDto readAlarm(Long alarmId);
 
 	public List<Alarm> findAllUnReadAlarmByUserId(Long userId);
+
+	public Long countUnReadAlarmByUserId(Long userId);
 }

--- a/src/main/java/com/grabpt/service/AlarmService/AlarmServiceImpl.java
+++ b/src/main/java/com/grabpt/service/AlarmService/AlarmServiceImpl.java
@@ -42,7 +42,7 @@ public class AlarmServiceImpl implements AlarmService {
 			.build();
 		alarmRepository.save(alarm);
 
-		messagingTemplate.convertAndSend("/subscribe/alarm/"+user.getId(), findAllUnReadAlarmByUserId(userId).size());
+		messagingTemplate.convertAndSend("/subscribe/alarm/"+user.getId(), countUnReadAlarmByUserId(userId));
 		log.info("Alarm sent to user: {}", user.getId());
 	}
 
@@ -53,14 +53,20 @@ public class AlarmServiceImpl implements AlarmService {
 		Alarm alarm = alarmRepository.findById(alarmId).orElseThrow(
 			()->new AlarmHandler(ErrorStatus.ALARM_NOT_FOUND)
 		);
+		Long userId = alarm.getUser().getId();
 		alarm.setRead(true);
-		alarmRepository.save(alarm);
+		messagingTemplate.convertAndSend("/subscribe/alarm/"+userId, countUnReadAlarmByUserId(userId));
 		return AlarmConverter.toAlarmResponseDto(alarm);
 	}
 
 	@Override
 	public List<Alarm> findAllUnReadAlarmByUserId(Long userId){
 		return alarmRepository.findAllUnReadAlarmByUserId(userId);
+	}
+
+	@Override
+	public Long countUnReadAlarmByUserId(Long userId){
+		return alarmRepository.countUnReadAlarmByUserId(userId);
 	}
 
 }


### PR DESCRIPTION
## PR 제목
[Feat] 알림 읽을 시에도 안읽은 알림 개수 웹소켓으로 전달

## 변경 사항
- AlarmRepository에 안읽은 알림개수 구하는 로직 추가
- 알림 읽을 시에도 웹소켓으로 안읽은 알림 개수 전달

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #113 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
