### PR TITLE
[Feat] 계약서 작성 시 전자서명 저장 및 트레이너에게 알림

### DIFF
--- a/src/main/java/com/grabpt/controller/MatchingController.java
+++ b/src/main/java/com/grabpt/controller/MatchingController.java
@@ -1,5 +1,6 @@
 package com.grabpt.controller;
 
+import com.grabpt.dto.response.ContractResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,10 +24,10 @@ public class MatchingController {
 	private final MatchingService matchingService;
 
 	@PostMapping
-	@Operation(summary = "요청-제안 매칭 API", description = "요청서와 제안서 기반으로 매칭 생성")
-	public ApiResponse<String> createMatching(@RequestParam Long requestionId, @RequestParam Long suggestionId) {
-		Matching matched = matchingService.createMatching(requestionId, suggestionId);
-		return ApiResponse.onSuccess("매칭 완료 (ID: " + matched.getId() + ")");
+	@Operation(summary = "요청-제안 매칭 API", description = "요청서와 제안서 기반으로 매칭 생성(matchingId, contractId 반환)")
+	public ApiResponse<ContractResponse.CreateMatchingAndContractResponseDto> createMatching(@RequestParam Long requestionId, @RequestParam Long suggestionId) {
+		matchingService.createMatching(requestionId, suggestionId);
+		return ApiResponse.onSuccess(matchingService.createMatching(requestionId, suggestionId));
 	}
 
 	@PostMapping("/{matchingId}/status")

--- a/src/main/java/com/grabpt/domain/entity/Contract.java
+++ b/src/main/java/com/grabpt/domain/entity/Contract.java
@@ -43,7 +43,8 @@ public class Contract extends BaseEntity {
 		@AttributeOverride(name = "birth", column = @Column(name = "user_birth")),
 		@AttributeOverride(name = "phoneNumber", column = @Column(name = "user_phone_number")),
 		@AttributeOverride(name = "gender", column = @Column(name = "user_gender")),
-		@AttributeOverride(name = "address", column = @Column(name = "user_address"))
+		@AttributeOverride(name = "address", column = @Column(name = "user_address")),
+		@AttributeOverride(name = "signUrl", column = @Column(name = "user_signUrl"))
 	})
 	private ContractInfo userInfo;
 
@@ -53,7 +54,8 @@ public class Contract extends BaseEntity {
 		@AttributeOverride(name = "birth", column = @Column(name = "pro_birth")),
 		@AttributeOverride(name = "phoneNumber", column = @Column(name = "pro_phone_number")),
 		@AttributeOverride(name = "gender", column = @Column(name = "pro_gender")),
-		@AttributeOverride(name = "address", column = @Column(name = "pro_address"))
+		@AttributeOverride(name = "address", column = @Column(name = "pro_address")),
+		@AttributeOverride(name = "signUrl", column = @Column(name = "pro_signUrl"))
 	})
 	private ContractInfo proInfo;
 

--- a/src/main/java/com/grabpt/domain/entity/ContractInfo.java
+++ b/src/main/java/com/grabpt/domain/entity/ContractInfo.java
@@ -24,4 +24,6 @@ public class ContractInfo {
 	private Gender gender;
 
 	private String address;
+
+	private String signUrl;
 }

--- a/src/main/java/com/grabpt/dto/request/ContractRequest.java
+++ b/src/main/java/com/grabpt/dto/request/ContractRequest.java
@@ -28,5 +28,8 @@ public class ContractRequest {
 
 		@Schema(description = "주소", example = "서울시 강남구")
 		private String address;
+
+		@Schema(description = "전자서명 이미지")
+		private String signUrl;
 	}
 }

--- a/src/main/java/com/grabpt/dto/response/ContractResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ContractResponse.java
@@ -21,4 +21,11 @@ public class ContractResponse {
 		String ptAddress;
 		MatchingStatus status;
 	}
+
+	@Getter
+	@Builder
+	public static class CreateMatchingAndContractResponseDto {
+		Long matchingId;
+		Long contractId;
+	}
 }

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -14,6 +14,7 @@ import com.grabpt.repository.ContractRepository.ContractRepository;
 import com.grabpt.service.AlarmService.AlarmService;
 import com.grabpt.service.PdfService.PdfGenerateService;
 
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,13 +40,12 @@ public class ContractServiceImpl implements ContractService {
 		Contract contract = contractRepository.findById(contractId).orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
 		contract.getMatching().setStatus(MatchingStatus.USERWROTE);
 
-		ContractInfo userInfo = new ContractInfo();
-		userInfo.setAddress(request.getAddress());
-		userInfo.setName(request.getName());
-		userInfo.setBirth(request.getBirth());
-		userInfo.setGender(request.getGender());
-		userInfo.setPhoneNumber(request.getPhoneNumber());
-		contract.setUserInfo(userInfo);
+		ContractInfo contractInfo = toContractInfo(request);
+		contract.setUserInfo(contractInfo);
+
+		Long proId = contract.getMatching().getSuggestion().getProProfile().getUser().getId();
+		alarmService.sendAlarm(proId, "CONTRACT", "수강생 계약서 작성 완료",
+			contractInfo.getName()+"님이 계약서 작성을 완료했습니다. 계약서를 작성해주세요.", "/contract/"+contractId);
 		return contract;
 	}
 
@@ -55,18 +55,24 @@ public class ContractServiceImpl implements ContractService {
 		Contract contract = contractRepository.findById(contractId).orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
 		contract.getMatching().setStatus(MatchingStatus.COMPLETED);
 
+		ContractInfo contractInfo = toContractInfo(request);
+		contract.setProInfo(contractInfo);
+
+		Long userId = contract.getMatching().getRequestion().getUser().getId(); //너무 길긴 함
+		alarmService.sendAlarm(userId, "PAYMENT", "전문가 계약서 작성 완료",
+			contractInfo.getName()+"님의 계약서 작성이 완료되었어요. 결제를 진행해주세요", "/contract/"+contractId);
+		return contract;
+	}
+
+	private ContractInfo toContractInfo(ContractRequest.ContractInfoDto request) {
 		ContractInfo userInfo = new ContractInfo();
 		userInfo.setAddress(request.getAddress());
 		userInfo.setName(request.getName());
 		userInfo.setBirth(request.getBirth());
 		userInfo.setGender(request.getGender());
 		userInfo.setPhoneNumber(request.getPhoneNumber());
-		contract.setProInfo(userInfo); //수정
-
-		Long userId = contract.getMatching().getRequestion().getUser().getId(); //너무 길긴 함
-		alarmService.sendAlarm(userId, "CONTRACT", "계약서 작성 완료",
-			"계약서 작성이 완료되었어요. 결제를 진행해주세요", "/contract/"+contractId);
-		return contract;
+		userInfo.setSignUrl(request.getSignUrl());
+		return userInfo;
 	}
 
 	@Override

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -77,7 +77,7 @@ public class ContractServiceImpl implements ContractService {
 			.price(sug.getPrice())
 			.ptAddress(sug.getLocation())
 			.startDate(req.getStartPreference())
-			.totalSession(req.getSessionCount())
+			.totalSession(sug.getSessionCount())
 			.build();
 
 		return contractRepository.save(contract);

--- a/src/main/java/com/grabpt/service/MatchingService/MatchingService.java
+++ b/src/main/java/com/grabpt/service/MatchingService/MatchingService.java
@@ -2,9 +2,10 @@ package com.grabpt.service.MatchingService;
 
 import com.grabpt.domain.entity.Matching;
 import com.grabpt.domain.enums.MatchingStatus;
+import com.grabpt.dto.response.ContractResponse;
 
 public interface MatchingService {
-	Matching createMatching(Long requestionId, Long suggestionId);
+	ContractResponse.CreateMatchingAndContractResponseDto createMatching(Long requestionId, Long suggestionId);
 
 	Matching updateStatus(Long matchingId, MatchingStatus newStatus);
 

--- a/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
+++ b/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
@@ -2,6 +2,8 @@ package com.grabpt.service.MatchingService;
 
 import java.time.LocalDateTime;
 
+import com.grabpt.domain.entity.Contract;
+import com.grabpt.dto.response.ContractResponse;
 import org.springframework.stereotype.Service;
 
 import com.grabpt.apiPayload.code.status.ErrorStatus;
@@ -29,7 +31,7 @@ public class MatchingServiceImpl implements MatchingService {
 	private final ContractService contractService;
 
 	@Override
-	public Matching createMatching(Long requestionId, Long suggestionId) {
+	public ContractResponse.CreateMatchingAndContractResponseDto createMatching(Long requestionId, Long suggestionId) {
 
 		Requestions requestion = requestionRepository.findById(requestionId)
 			.orElseThrow(() -> new RequestionHandler(ErrorStatus.REQUESTION_NOT_FOUND));
@@ -55,10 +57,12 @@ public class MatchingServiceImpl implements MatchingService {
 
 		matchingRepository.save(matching);
 		requestionRepository.save(requestion); // 상태 저장 반영
-		contractService.createContract(matching, requestion, suggestion);
+		Contract contract = contractService.createContract(matching, requestion, suggestion);
 
-		return matching;
-
+		return ContractResponse.CreateMatchingAndContractResponseDto.builder()
+			.matchingId(matching.getId())
+			.contractId(contract.getId())
+			.build();
 	}
 
 	@Override


### PR DESCRIPTION
## PR 제목
- [Feat] 회원가입 API 구현
- [Fix] 로그인 예외 처리 수정

## 변경 사항
- 매칭 시 계약서 id리턴
- 작성할 때 사진 저장
- 이미지 url로 리턴 
- 매칭 트레이너한테 알람

## 관련 이슈
- 관련 이슈 번호: #88 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
