### PR TITLE
[Fix] 전문가 요청서 목록 조회 시 지역+카테고리 기반

### DIFF
--- a/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
+++ b/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.LockModeType.*;
 import java.util.List;
 import java.util.Optional;
 
+import com.grabpt.domain.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,14 +33,9 @@ public interface RequestionRepository extends JpaRepository<Requestions, Long> {
 	Page<Requestions> findByLocationOrderByCreatedAtDesc(String location, Pageable pageable);
 
 	// 최신순(주소변경)
-	Page<Requestions> findByLocationStartingWithOrderByCreatedAtDesc(String locationPrefix, Pageable pageable);
-
-	// 가격 높은 순
-	Page<Requestions> findByLocationOrderByPriceDesc(String location, Pageable pageable);
-
+	Page<Requestions> findByLocationStartingWithAndCategoryOrderByCreatedAtDesc(String locationPrefix, Category category, Pageable pageable);
 	// 가격 높은 순(주소변경)
-	Page<Requestions> findByLocationStartingWithOrderByPriceDesc(String locationPrefix, Pageable pageable);
-
+	Page<Requestions> findByLocationStartingWithAndCategoryOrderByPriceDesc(String locationPrefix, Category category, Pageable pageable);
 	// 기본 요청서 조회
 	Page<Requestions> findByLocation(String locationPrefix, Pageable pageable);
 

--- a/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
@@ -103,6 +103,7 @@ public class RequestionServiceImpl implements RequestionService {
 			() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
 		Address addr = findProUser.getAddress();
+		findProUser.getProProfile().getCategory().getId();
 		String proAddressPrefix = buildAddressPrefix(addr); // "서울시 강남구 역삼동"
 		log.info("RequestServiceImpl pro address prefix = {}", proAddressPrefix);
 
@@ -111,17 +112,14 @@ public class RequestionServiceImpl implements RequestionService {
 			return Page.empty(pageable);
 		}
 
-		// String proStreet = findProUser.getAddress().getStreet();
-		// log.info("RequestServiceImpl 내부 프로 address = " + proStreet);
-
 		Page<Requestions> requestionPage;
-
+		Category category = findProUser.getProProfile().getCategory();
 		if ("price".equalsIgnoreCase(sortBy)) {
 			requestionPage = requestionRepository
-				.findByLocationStartingWithOrderByPriceDesc(proAddressPrefix, pageable);
+				.findByLocationStartingWithAndCategoryOrderByPriceDesc(proAddressPrefix, category, pageable);
 		} else {
 			requestionPage = requestionRepository
-				.findByLocationStartingWithOrderByCreatedAtDesc(proAddressPrefix, pageable);
+				.findByLocationStartingWithAndCategoryOrderByCreatedAtDesc(proAddressPrefix, category, pageable);
 		}
 
 		return requestionPage.map(req -> {


### PR DESCRIPTION
## PR 제목
- [Fix] 전문가 요청서 목록 조회 시 지역+카테고리 기반

## 변경 사항
- Repository로직에 Category추가

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #21 
