### PR TITLE
[Fix] 실시간 매칭 현황 8개로 수정, 메시지 sentAt변경

### DIFF
--- a/src/main/java/com/grabpt/controller/CategoryRestController.java
+++ b/src/main/java/com/grabpt/controller/CategoryRestController.java
@@ -101,7 +101,7 @@ public class CategoryRestController {
 	@GetMapping("/requests/{code}")
 	public ApiResponse<List<CategoryResponse.RequestListDto>> getRequestList(@PathVariable(name = "code") String code) {
 
-		Pageable pageable = PageRequest.of(0,6);
+		Pageable pageable = PageRequest.of(0,8);
 		List<Requestions> reqeustions = requestionService.getReqeustions(code, pageable);
 		return ApiResponse.onSuccess(CategoryConverter.toRequestListDto(reqeustions));
 	}

--- a/src/main/java/com/grabpt/converter/ChatConverter.java
+++ b/src/main/java/com/grabpt/converter/ChatConverter.java
@@ -9,6 +9,7 @@ import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public class ChatConverter {
 	public static ChatResponse.CreateChatRoomResponseDto toCreateChatRoomResponseDto(UserChatRoom room) {
@@ -23,7 +24,7 @@ public class ChatConverter {
 			.chatRoom(chatRoom)
 			.type(MessageType.fromString(request.getMessageType()))
 			.content(request.getContent())
-			.sentAt(LocalDateTime.now())
+			.sentAt(LocalDateTime.now(ZoneId.of( "Asia/Seoul")))
 			.readCount(1)
 			.build();
 	}

--- a/src/main/java/com/grabpt/domain/entity/Messages.java
+++ b/src/main/java/com/grabpt/domain/entity/Messages.java
@@ -2,6 +2,7 @@ package com.grabpt.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
@@ -53,7 +54,7 @@ public class Messages extends BaseEntity {
 	@Column
 	private String content;
 
-	@CreatedDate
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime sentAt;
 
 	@Column

--- a/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
+++ b/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
@@ -27,7 +27,7 @@ public interface RequestionRepository extends JpaRepository<Requestions, Long> {
 			WHERE r.category.code =:categoryCode
 			ORDER BY r.createdAt DESC
 		""")
-	List<Requestions> findTop6RequestionsByCategory(@Param("categoryCode") String categoryCode, Pageable pageable);
+	List<Requestions> findTop8RequestionsByCategory(@Param("categoryCode") String categoryCode, Pageable pageable);
 
 	// 최신순
 	Page<Requestions> findByLocationOrderByCreatedAtDesc(String location, Pageable pageable);

--- a/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
@@ -46,7 +46,7 @@ public class RequestionServiceImpl implements RequestionService {
 
 	@Override
 	public List<Requestions> getReqeustions(String categoryCode, Pageable pageable) {
-		return requestionRepository.findTop6RequestionsByCategory(categoryCode, pageable);
+		return requestionRepository.findTop8RequestionsByCategory(categoryCode, pageable);
 	}
 
 	@Override


### PR DESCRIPTION
## PR 제목
- [Fix] 실시간 매칭 현황 8개로 수정, 메시지 sentAt변경

## 변경 사항
- 실시간 매칭 현황 8개 가져오는 것으로 수정
- 메시지 sentAt 한국시간으로 되라 제발

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #12

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
