### PR TITLE
[Feat] pricePerQuery 반환 로직 구현

### DIFF
--- a/src/main/java/com/grabpt/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/grabpt/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -91,14 +91,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
 		}
 	}
 
-	// 삭제 없이 로드만 (프레임워크 일부 코드가 이 오버로드를 호출)
-	// @Override
-	// public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
-	// 	log.debug("[OAUTH][REMOVE-noresp] uri={}", request.getRequestURI());
-	// 	return loadAuthorizationRequest(request);
-	// }
-
-	// ★ 실제 삭제는 여기서만 수행 (성공/실패 처리 시점)
+	// 실제 삭제는 여기서만 수행 (성공/실패 처리 시점)
 	@Override
 	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
 		HttpServletResponse response) {

--- a/src/main/java/com/grabpt/controller/PriceQueryController.java
+++ b/src/main/java/com/grabpt/controller/PriceQueryController.java
@@ -1,0 +1,32 @@
+package com.grabpt.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grabpt.apiPayload.ApiResponse;
+import com.grabpt.service.priceService.PriceQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController("/api")
+@RequiredArgsConstructor
+public class PriceQueryController {
+
+	private final PriceQueryService priceQueryService;
+
+	/**
+	 * 예) /price/avg-per-session?categoryName=PT&city=서울&district=강남구&street=역삼동
+	 * "서울 강남구 역삼동%" 만 집계
+	 */
+	@GetMapping("/price/avg-per-session")
+	public ApiResponse<PriceQueryService.IntAvgPriceResult> getAvgUnitPrice(
+		@RequestParam String categoryName,
+		@RequestParam String city,
+		@RequestParam String district,
+		@RequestParam String street
+	) {
+		var result = priceQueryService.getAvgUnitPrice(categoryName, city, district, street);
+		return ApiResponse.onSuccess(result);
+	}
+}

--- a/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
+++ b/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
@@ -49,4 +49,35 @@ public interface RequestionRepository extends JpaRepository<Requestions, Long> {
 	@Lock(PESSIMISTIC_WRITE)
 	@Query("select r from Requestions r where r.id = :id")
 	Optional<Requestions> findByIdForUpdate(@Param("id") Long id);
+
+	/**
+	 * 정확히 전달받은 fullRegion(예: "서울 강남구 역삼동")으로 시작하는 location만 집계.
+	 * - 점진적 확장 없음(동→구→시로 내려가지 않음)
+	 * - sessionCount > 0만 집계
+	 * - category.name으로 필터
+	 * - 실수 평균 보장
+	 */
+	@Query("""
+		    select coalesce(avg(1.0 * r.price / r.sessionCount), 0.0)
+		    from Requestions r
+		    where r.sessionCount > 0
+		      and r.category.name = :categoryName
+		      and r.location like concat(:fullRegion, '%')
+		""")
+	double avgUnitPriceByCategoryAndRegion(
+		@Param("categoryName") String categoryName,
+		@Param("fullRegion") String fullRegion
+	);
+
+	@Query("""
+		    select count(r)
+		    from Requestions r
+		    where r.sessionCount > 0
+		      and r.category.name = :categoryName
+		      and r.location like concat(:fullRegion, '%')
+		""")
+	long countByCategoryAndRegion(
+		@Param("categoryName") String categoryName,
+		@Param("fullRegion") String fullRegion
+	);
 }

--- a/src/main/java/com/grabpt/service/priceService/PriceQueryService.java
+++ b/src/main/java/com/grabpt/service/priceService/PriceQueryService.java
@@ -1,0 +1,40 @@
+package com.grabpt.service.priceService;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grabpt.repository.RequestionRepository.RequestionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceQueryService {
+
+	private final RequestionRepository requestionRepository;
+
+	public static record IntAvgPriceResult(int avgUnitPrice, long sampleCount) {
+	}
+
+	public IntAvgPriceResult getAvgUnitPrice(String categoryName, String city, String district, String street) {
+		String fullRegion = buildFullRegion(city, district, street);
+
+		double avg = requestionRepository.avgUnitPriceByCategoryAndRegion(categoryName, fullRegion); // double
+		long cnt = requestionRepository.countByCategoryAndRegion(categoryName, fullRegion);
+
+		// 소수점 제거 방식 선택:
+		int avgInt = (int)Math.floor(avg);         // ① 버림 (기본)
+		// int avgInt = (int) Math.round(avg);      // ② 반올림
+		// int avgInt = (int) Math.ceil(avg);       // ③ 올림
+
+		return new IntAvgPriceResult(avgInt, cnt);
+	}
+
+	private String buildFullRegion(String city, String district, String street) {
+		String c = city == null ? "" : city.trim();
+		String d = district == null ? "" : district.trim();
+		String s = street == null ? "" : street.trim();
+		return String.join(" ", new String[] {c, d, s}).trim().replaceAll("\\s+", " ");
+	}
+}


### PR DESCRIPTION
## PR 제목
- [Feat] pricePerQuery 반환 로직 구현

## 변경 사항
- 카테고리 이름, 시, 구, 동을 파라미터로 받아서 해당 카테고리와 지역에 해당하는 제안서의 가격을 조회
- 여러 세션을 가진 제안서는 1회당으로 변환 후 합해서 계산

## 작업 내용 체크
- 기능 동작 확인

