### PR TITLE
[Fix] review profileimageurl 반환 수정

### DIFF
--- a/src/main/java/com/grabpt/dto/response/MyReviewListDTO.java
+++ b/src/main/java/com/grabpt/dto/response/MyReviewListDTO.java
@@ -2,6 +2,7 @@ package com.grabpt.dto.response;
 
 import com.grabpt.domain.entity.Review;
 import com.grabpt.domain.entity.Users;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,8 +36,6 @@ public class MyReviewListDTO {
 
 	private String imageURL;
 
-
-
 	public static MyReviewListDTO from(Review review) {
 		Users user = review.getUser();
 
@@ -49,7 +48,7 @@ public class MyReviewListDTO {
 			.center(review.getProProfile().getCenter())
 			.proId(review.getProProfile().getUser().getId())
 			.proNickName(review.getProProfile().getUser().getNickname())
-			.imageURL(review.getProProfile().getUser().getProfileImageUrl())
+			.imageURL(user.getProfileImageUrl())
 			.build();
 	}
 }


### PR DESCRIPTION
## PR 제목
- [Fix] review profileimageurl 반환 수정

## 변경 사항
- 리뷰를 작성한 유저 이름을 반환하지 않고 트레이너 사진을 반환하는 버그 수정

## 작업 내용 체크
- 기능 동작 확인
