### PR TITLE
[Feat] 회원탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/grabpt/config/MemberScheduler.java
+++ b/src/main/java/com/grabpt/config/MemberScheduler.java
@@ -23,18 +23,7 @@ public class MemberScheduler {
 		LocalDateTime deleteDate = LocalDateTime.now().minusDays(30);
 		List<Users> expiredUsers = userRepository.findByRoleAndDeletedAtBefore(Role.DELETED, deleteDate);
 
-		for (Users user : expiredUsers) {
-			user.setUsername("탈퇴한 회원");
-			user.setNickname("탈퇴한 회원");
-			user.setEmail("deleted@" + user.getId());
-			user.setOauthId(null);
-			user.setOauthProvider(null);
-			user.setPhone_number("");
-			user.setProfileImageUrl(null);
-			user.setRefreshToken(null);
-			user.setUserProfile(null);
-			user.setProProfile(null);
-		}
+		for (Users user : expiredUsers) userRepository.delete(user);
 
 
 	}

--- a/src/main/java/com/grabpt/controller/MyProfileController.java
+++ b/src/main/java/com/grabpt/controller/MyProfileController.java
@@ -134,6 +134,8 @@ public class MyProfileController {
 		Long userId = principalDetails.getUser().getId();
 
 		profileService.deleteUser(userId, requestDto);
+
+
 		log.info("[WITHDRAW] User data deleted for userId: {}", userId);
 
 		log.info("[WITHDRAW] Starting session & cookie cleanup process...");

--- a/src/main/java/com/grabpt/domain/entity/PreviousUser.java
+++ b/src/main/java/com/grabpt/domain/entity/PreviousUser.java
@@ -1,0 +1,45 @@
+package com.grabpt.domain.entity;
+
+import com.grabpt.domain.enums.AuthRole;
+import com.grabpt.domain.enums.Gender;
+import com.grabpt.domain.enums.Role;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+public class PreviousUser {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "previous_id")
+	private Long id;
+
+	private String nickname;
+
+	private String username;
+
+	private String profileImageUrl;
+
+	private Role role;
+
+	private Gender gender;
+
+	private String phone_number;
+
+	private String email;
+
+	@OneToOne
+	@JoinColumn(name = "user_id")
+	private Users user;
+
+	public void setUser(Users user) {
+		this.user = user;
+		if (user != null && user.getPreviousUser() != this) {
+			user.setPreviousUser(this);
+		}
+	}
+}

--- a/src/main/java/com/grabpt/domain/entity/Suggestions.java
+++ b/src/main/java/com/grabpt/domain/entity/Suggestions.java
@@ -4,24 +4,13 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import com.grabpt.domain.common.BaseEntity;
 import com.grabpt.domain.enums.SuggestStatus;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +32,9 @@ public class Suggestions extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "suggestions_id")
 	private Long id;
+
+	@OneToOne(mappedBy = "suggestion", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Matching matching;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "requestions_id")

--- a/src/main/java/com/grabpt/domain/entity/Users.java
+++ b/src/main/java/com/grabpt/domain/entity/Users.java
@@ -28,6 +28,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.cfg.CacheSettings;
 
 @Entity
 @Getter
@@ -85,9 +86,6 @@ public class Users extends BaseEntity {
 	@Column(length = 500)
 	private String deletionReason; // 회원탈퇴 사유
 
-	@Enumerated(EnumType.STRING)
-	private Role previousRole;
-
 	// 선택 약관 (마케팅 정보 수신 동의)
 	private Boolean agreeMarketing;
 	private LocalDateTime agreeMarketingAt;
@@ -98,6 +96,9 @@ public class Users extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<UserChatRoom> userChatRooms = new ArrayList<>();
 
+	@OneToMany(mappedBy = "otherUser", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<UserChatRoom> otherUserChatRooms = new ArrayList<>();
+
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Address address;
 
@@ -105,11 +106,20 @@ public class Users extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Requestions> requestions = new ArrayList<>();
 
+	@OneToMany(mappedBy = "sender", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Messages> sentMessages = new ArrayList<>();
+
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private UserProfile userProfile;
 
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private ProProfile proProfile;
+
+	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private PreviousUser previousUser;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Alarm> alarms = new ArrayList<>();
 
 	public void setAddress(Address address) {
 		this.address = address;
@@ -137,6 +147,13 @@ public class Users extends BaseEntity {
 		this.requestions.add(requestion);
 		if (requestion.getUser() != this) {
 			requestion.setUser(this);
+		}
+	}
+
+	public void setPreviousUser(PreviousUser previousUser) {
+		this.previousUser = previousUser;
+		if (previousUser != null && previousUser.getUser() != this) {
+			previousUser.setUser(this);
 		}
 	}
 

--- a/src/main/java/com/grabpt/service/ProfileService/ProfileServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ProfileService/ProfileServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.grabpt.domain.entity.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,13 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.grabpt.apiPayload.code.status.ErrorStatus;
 import com.grabpt.apiPayload.exception.GeneralException;
 import com.grabpt.converter.ProfileConverter;
-import com.grabpt.domain.entity.Address;
-import com.grabpt.domain.entity.Matching;
-import com.grabpt.domain.entity.ProProfile;
-import com.grabpt.domain.entity.PtPrice;
-import com.grabpt.domain.entity.Requestions;
-import com.grabpt.domain.entity.Review;
-import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.MatchingStatus;
 import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.CenterUpdateRequestDTO;
@@ -335,22 +329,38 @@ public class ProfileServiceImpl implements ProfileService {
 		Users user = userRepository.findById(userId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-		user.setPreviousRole(user.getRole());
+		PreviousUser previousUser = user.getPreviousUser();
+		if (previousUser == null) {
+			previousUser = new PreviousUser();
+			previousUser.setUser(user);
+			user.setPreviousUser(previousUser);
+		}
+
+		previousUser.setRole(user.getRole());
 		user.setRole(Role.DELETED);
+
 		user.setDeletedAt(LocalDateTime.now());
 		user.setDeletionReason(deletedRequest.getDeletionReason());
-		user.setUsername("탈퇴한 회원");
-		user.setNickname("탈퇴한 회원");
-		user.setEmail("deleted@" + user.getId());
-		user.setOauthId(null);
-		user.setOauthProvider(null);
-		user.setPhone_number("");
-		user.setProfileImageUrl(null);
-		user.setRefreshToken(null);
-		user.setUserProfile(null);
-		user.setProProfile(null);
 
-		userRepository.save(user);
+		previousUser.setUsername(user.getUsername());
+		user.setUsername("탈퇴한 회원");
+		previousUser.setNickname(user.getNickname());
+		user.setNickname("탈퇴한 회원");
+
+		previousUser.setProfileImageUrl(user.getProfileImageUrl());
+		user.setProfileImageUrl(null);
+
+		previousUser.setPhone_number(user.getPhone_number());
+		user.setPhone_number("010-0000-0000");
+
+		previousUser.setEmail(user.getEmail());
+		user.setEmail("deleted@" + user.getId());
+
+		user.setAccessToken(null);
+		user.setRefreshToken(null);
+
+
+
 	}
 
 	@Override
@@ -359,10 +369,17 @@ public class ProfileServiceImpl implements ProfileService {
 		Users user = userRepository.findById(userId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
+		PreviousUser previousUser = user.getPreviousUser();
+
 		LocalDateTime recoveryDate = LocalDateTime.now().minusDays(30);
 
 		if (user.getRole() == Role.DELETED && user.getDeletedAt().isAfter(recoveryDate)) {
-			user.setRole(user.getPreviousRole());
+			user.setRole(previousUser.getRole());
+			user.setNickname(previousUser.getNickname());
+			user.setUsername(previousUser.getUsername());
+			user.setProfileImageUrl(previousUser.getProfileImageUrl());
+			user.setPhone_number(previousUser.getPhone_number());
+			user.setEmail(previousUser.getEmail());
 			user.setDeletedAt(null);
 			user.setDeletionReason(null);
 		} else {


### PR DESCRIPTION
- 회원탈퇴 로직 수정

회원 탈퇴 이후 30일 이내에 복구 가능하도록 설정하였고 스케쥴러를 활용하였습니다.

회원탈퇴 이후 토큰이 사라지는 거 같아, restore을 하기 전에 reissue를 통해 토큰을 재발급을 받아야 하는데

프론트엔드 측에서 이를 처리할 수 있는지 혹은 온보딩 과정에서 리다이렉션을 통해 복구 과정을 물어볼 수 있는지에 대한 과정 논의가 필요합니다.