### PR TITLE
[Refactor] 채팅방 입장 시 메시지 읽음 처리 성능 개선

### DIFF
--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -6,6 +6,7 @@ import com.grabpt.converter.ChatConverter;
 import com.grabpt.domain.entity.Messages;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 import com.grabpt.service.ChatService.ChatFacade;
 import com.grabpt.service.ChatService.ChatRoomService;
 import com.grabpt.service.ChatService.MessageService;
@@ -137,14 +138,14 @@ public class ChatController {
 			description = "채팅방 불러오기 성공",
 			content = @Content(
 				mediaType = "application/json",
-				schema = @Schema(implementation = ChatResponse.ChatRoomPreviewDto.class)
+				schema = @Schema(implementation = ChatRoomPreviewDto.class)
 			)),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
 	})
 	@GetMapping("/chatRoom/list") //로그인 유저 정보
 	@ResponseBody
-	public ApiResponse<List<ChatResponse.ChatRoomPreviewDto>> getChatRoomList(@RequestParam(name = "keyword", required = false) String keyword){
+	public ApiResponse<List<ChatRoomPreviewDto>> getChatRoomList(@RequestParam(name = "keyword", required = false) String keyword){
 		Long userId = SecurityUtils.currentUserIdOrThrow();
 		return ApiResponse.onSuccess(chatRoomService.getChatRoomList(userId, keyword));
 	}

--- a/src/main/java/com/grabpt/converter/ChatConverter.java
+++ b/src/main/java/com/grabpt/converter/ChatConverter.java
@@ -7,6 +7,7 @@ import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.MessageType;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -41,16 +42,4 @@ public class ChatConverter {
 			.build();
 	}
 
-	public static ChatResponse.ChatRoomPreviewDto toChatRoomPreviewDto(UserChatRoom userChatRoom, Long unreadCount){
-		return ChatResponse.ChatRoomPreviewDto.builder()
-			.roomId(userChatRoom.getChatRoom().getId())
-			.userId(userChatRoom.getUser().getId())
-			.otherUserId(userChatRoom.getOtherUser().getId())
-			.unreadCount(unreadCount)
-			.otherUserProfileImageUrl(userChatRoom.getOtherUser().getProfileImageUrl())
-			.roomName(userChatRoom.getOtherUser().getNickname())
-			.lastMessage(userChatRoom.getChatRoom().getLastMessage())
-			.lastMessageTime(userChatRoom.getChatRoom().getLastMessageTime())
-			.build();
-	}
 }

--- a/src/main/java/com/grabpt/dto/response/ChatResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ChatResponse.java
@@ -49,25 +49,6 @@ public class ChatResponse {
 	@Setter
 	@Getter
 	@Builder
-	public static class ChatRoomPreviewDto{
-		Long roomId;
-		Long userId;
-		Long otherUserId;
-		Long unreadCount; //추가
-		@Schema(example = "뎀프시롤")
-		String roomName;
-		@Schema(example = "ㅎㅇㅎㅇ")
-		String lastMessage;
-		@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-		LocalDateTime lastMessageTime;
-		String otherUserProfileImageUrl;
-	}
-
-	@AllArgsConstructor
-	@NoArgsConstructor
-	@Setter
-	@Getter
-	@Builder
 	public static class ReadStatusUpdateDto{
 		Long messageId;
 		int readCount;

--- a/src/main/java/com/grabpt/dto/response/ChatRoomPreviewDto.java
+++ b/src/main/java/com/grabpt/dto/response/ChatRoomPreviewDto.java
@@ -1,0 +1,36 @@
+package com.grabpt.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ChatRoomPreviewDto {
+	Long roomId;
+	Long userId;
+	Long otherUserId;
+	String otherUserProfileImageUrl;
+	@Schema(example = "뎀프시롤")
+	String roomName;
+	@Schema(example = "ㅎㅇㅎㅇ")
+	String lastMessage;
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+	LocalDateTime lastMessageTime;
+	Long unreadCount; //추가
+
+	public ChatRoomPreviewDto(Long roomId, Long userId, Long otherUserId, String otherUserProfileImageUrl, String roomName, String lastMessage, LocalDateTime lastMessageTime) {
+		this.roomId = roomId;
+		this.userId = userId;
+		this.otherUserId = otherUserId;
+		this.otherUserProfileImageUrl = otherUserProfileImageUrl;
+		this.roomName = roomName;
+		this.lastMessage = lastMessage;
+		this.lastMessageTime = lastMessageTime;
+	}
+}

--- a/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
@@ -3,6 +3,7 @@ package com.grabpt.repository.ChatRepository;
 import com.grabpt.domain.entity.Messages;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -35,6 +36,15 @@ public interface MessageRepository extends JpaRepository<Messages, Long> {
 
 	@Query("SELECT m FROM Messages m WHERE m.chatRoom.id = :roomId AND m.readCount = 1 AND m.sender.id <> :userId")
 	List<Messages> findUnreadMessages(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("""
+	UPDATE Messages m SET m.readCount = 0
+	WHERE m.chatRoom.id = :roomId
+	AND m.sender.id <> :userId
+	AND m.readCount = 1
+	""")
+	void markAsReadAllInRoom(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
 	@Query("""
     SELECT m.chatRoom.id, COUNT(m)

--- a/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
@@ -1,6 +1,8 @@
 package com.grabpt.repository.ChatRepository;
 
 import com.grabpt.domain.entity.UserChatRoom;
+import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,15 +15,23 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
 	Optional<UserChatRoom> findChatRoomByUserPair(@Param("userId") Long userId, @Param("proId") Long proId);
 
 	@Query("""
-    SELECT DISTINCT ucr FROM UserChatRoom ucr
-    JOIN FETCH ucr.chatRoom cr
-    JOIN FETCH ucr.user u
-    JOIN FETCH ucr.otherUser ou
-    WHERE u.id = :userId
-    AND (:keyword IS NULL OR :keyword = '' OR ucr.roomName LIKE %:keyword%)
-    ORDER BY cr.lastMessageTime DESC
-	""") //N+1문제 방지
-	List<UserChatRoom> findByUserId(Long userId, String keyword);
+   SELECT NEW com.grabpt.dto.response.ChatResponse.ChatRoomPreviewDto(
+       cr.id,
+       ucr.user.id,
+       ou.id,
+       ou.profileImageUrl,
+       ucr.roomName,
+       cr.lastMessage,
+       cr.lastMessageTime
+   )
+   FROM UserChatRoom ucr
+   JOIN ucr.chatRoom cr
+   JOIN ucr.otherUser ou
+   WHERE ucr.user.id = :userId
+   AND (:keyword IS NULL OR :keyword LIKE %:keyword%)
+   ORDER BY cr.lastMessageTime DESC
+	""")
+	List<ChatRoomPreviewDto> findChatRoomPreviewsByUserId(@Param("userId") Long userId, @Param("keyword") String keyword);
 
 	@Query("SELECT ucr.chatRoom.id FROM UserChatRoom ucr WHERE ucr.user.id = :userId")
 	List<Long> findChatRoomIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
@@ -23,6 +23,9 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
 	""") //N+1문제 방지
 	List<UserChatRoom> findByUserId(Long userId, String keyword);
 
+	@Query("SELECT ucr.chatRoom.id FROM UserChatRoom ucr WHERE ucr.user.id = :userId")
+	List<Long> findChatRoomIdsByUserId(@Param("userId") Long userId);
+
 	@Query("SELECT ucr FROM UserChatRoom ucr WHERE ucr.chatRoom.id = :roomId AND ucr.user.id = :userId")
 	Optional<UserChatRoom> findByRoomIdAndUserId(@Param("roomId") Long roomId, @Param("userId") Long userId);
 

--- a/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/UserChatRoomRepository.java
@@ -15,7 +15,7 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
 	Optional<UserChatRoom> findChatRoomByUserPair(@Param("userId") Long userId, @Param("proId") Long proId);
 
 	@Query("""
-   SELECT NEW com.grabpt.dto.response.ChatResponse.ChatRoomPreviewDto(
+   SELECT NEW com.grabpt.dto.response.ChatRoomPreviewDto(
        cr.id,
        ucr.user.id,
        ou.id,

--- a/src/main/java/com/grabpt/service/ChatService/ChatRoomService.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatRoomService.java
@@ -3,12 +3,13 @@ package com.grabpt.service.ChatService;
 import com.grabpt.domain.entity.ChatRooms;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomService {
 	 ChatResponse.CreateChatRoomResponseDto getOrcreateChatRoom(ChatRequest.CreateChatRoomRequestDto request);
-	 List<ChatResponse.ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword);
+	 List<ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword);
 	 Optional<ChatRooms> findById(Long id);
 }

--- a/src/main/java/com/grabpt/service/ChatService/ChatRoomServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatRoomServiceImpl.java
@@ -8,18 +8,19 @@ import com.grabpt.domain.entity.UserChatRoom;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 import com.grabpt.repository.ChatRepository.ChatRoomRepository;
 import com.grabpt.repository.ChatRepository.UserChatRoomRepository;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService{
@@ -73,24 +74,28 @@ public class ChatRoomServiceImpl implements ChatRoomService{
 	}
 
 	@Override //fetch join고려 //ChatRoom
-	public List<ChatResponse.ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword) {
-		Users user = userQueryService.findById(userId)
-			.orElseThrow(() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
+	@Transactional
+	public List<ChatRoomPreviewDto> getChatRoomList(Long userId, String keyword) {
+		long start = System.currentTimeMillis();
+		List<ChatRoomPreviewDto> chatRoomPreviews = userChatRoomService.findChatRoomPreviewsByUserId(userId, keyword);
 
-		List<UserChatRoom> chatRooms = userChatRoomService.findByUserId(userId, keyword);
+		if (chatRoomPreviews.isEmpty()) {
+			return Collections.emptyList();
+		}
 
-		List<Long> roomIds = chatRooms.stream()
-			.map(chatRoom -> chatRoom.getChatRoom().getId())
+		List<Long> roomIds = chatRoomPreviews.stream()
+			.map(chatRoom -> chatRoom.getRoomId())
 			.toList();
 		Map<Long, Long> unreadMessageCount = messageService.getUnreadMessageCount(roomIds, userId);
 
-		return chatRooms.stream()
-			.map(chatRoom -> {
-				Long roomId = chatRoom.getChatRoom().getId();
-				Long unreadCount = unreadMessageCount.getOrDefault(roomId, 0L);
-				return ChatConverter.toChatRoomPreviewDto(chatRoom, unreadCount);
-			})
-			.toList();
+		chatRoomPreviews.forEach(preview ->
+			preview.setUnreadCount(unreadMessageCount.getOrDefault(preview.getRoomId(), 0L))
+		);
+
+		long end = System.currentTimeMillis();
+		long time = end-start;
+		log.info("실행 시간:{}",time);
+		return chatRoomPreviews;
 	}
 
 	@Override

--- a/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
@@ -14,6 +14,7 @@ import com.grabpt.repository.ChatRepository.MessageRepository;
 import com.grabpt.service.AlarmService.AlarmService;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MessageServiceImpl implements MessageService{
@@ -60,13 +62,12 @@ public class MessageServiceImpl implements MessageService{
 		Users user = userQueryService.findById(userId)
 			.orElseThrow(() -> new UserHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-		List<UserChatRoom> chatRooms = userChatRoomService.findByUserId(userId, null);
+		List<Long> roomIds = userChatRoomService.findChatRoomIdsByUserId(userId);
 
-		List<Long> roomIds = chatRooms.stream()
-			.map(chatRoom -> chatRoom.getChatRoom().getId())
-			.toList();
 		Map<Long, Long> unreadMessageCount = getUnreadMessageCount(roomIds, userId);
-		return unreadMessageCount.values().stream().mapToLong(Long::longValue).sum();
+		return unreadMessageCount.values().stream()
+			.mapToLong(Long::longValue)
+			.sum();
 	}
 
 
@@ -98,26 +99,31 @@ public class MessageServiceImpl implements MessageService{
 	@Override
 	@Transactional
 	public void updateLastReadMessageWhenEnter(Long roomId, Long userId){
+		long startTime = System.currentTimeMillis(); // 시작 시간 측정
 		List<Messages> unreadMessages = messageRepository.findUnreadMessages(roomId, userId);
-		for (Messages msg : unreadMessages) {
-			msg.setReadCount(0);
-		}
-		messageRepository.saveAll(unreadMessages);
 
-		for (Messages msg : unreadMessages) {
-			broadcastReadStatus(roomId, msg);
+		if(!unreadMessages.isEmpty()){
+			messageRepository.markAsReadAllInRoom(roomId,userId);
+
+			for (Messages msg : unreadMessages) {
+				broadcastReadStatus(roomId, msg);
+			}
 		}
 
 		UserChatRoom chatRoom = userChatRoomService.findByRoomIdAndUserId(roomId, userId).orElseThrow(
 			() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_FOUND));
-		Long lastMessageId = messageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId)
-			.map(Messages::getId)
-			.orElse(null);
-		chatRoom.setLastReadMessageId(lastMessageId);
-		chatRoom.setLastReadAt(LocalDateTime.now());
-		userChatRoomService.save(chatRoom);
+
+		messageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId)
+			.ifPresent(lastMessage -> {
+				chatRoom.setLastReadMessageId(lastMessage.getId());
+				chatRoom.setLastReadAt(LocalDateTime.now());
+			});
+
 
 		updateAllUnreadMessageCount(userId);
+		long endTime = System.currentTimeMillis(); // 종료 시간 측정
+		long duration = endTime - startTime; // 실행 시간 계산
+		log.info("실행시간:{}",duration);
 	}
 
 	@Override

--- a/src/main/java/com/grabpt/service/ChatService/UserChatRoomService.java
+++ b/src/main/java/com/grabpt/service/ChatService/UserChatRoomService.java
@@ -1,6 +1,7 @@
 package com.grabpt.service.ChatService;
 
 import com.grabpt.domain.entity.UserChatRoom;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +12,5 @@ public interface UserChatRoomService {
 	List<UserChatRoom> findByUserId(Long userId, String keyword);
 	Long getOtherUserId(Long userId, Long roomId);
 	Optional<UserChatRoom> findByRoomIdAndUserId(Long roomId, Long userId);
+	List<Long> findChatRoomIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/grabpt/service/ChatService/UserChatRoomService.java
+++ b/src/main/java/com/grabpt/service/ChatService/UserChatRoomService.java
@@ -1,6 +1,8 @@
 package com.grabpt.service.ChatService;
 
 import com.grabpt.domain.entity.UserChatRoom;
+import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -9,7 +11,7 @@ import java.util.Optional;
 public interface UserChatRoomService {
 	Optional<UserChatRoom> findChatRoomByUserPair(Long userId, Long proId);
 	void save(UserChatRoom room);
-	List<UserChatRoom> findByUserId(Long userId, String keyword);
+	List<ChatRoomPreviewDto> findChatRoomPreviewsByUserId(Long userId, String keyword);
 	Long getOtherUserId(Long userId, Long roomId);
 	Optional<UserChatRoom> findByRoomIdAndUserId(Long roomId, Long userId);
 	List<Long> findChatRoomIdsByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/grabpt/service/ChatService/UserChatRoomServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/UserChatRoomServiceImpl.java
@@ -1,6 +1,8 @@
 package com.grabpt.service.ChatService;
 
 import com.grabpt.domain.entity.UserChatRoom;
+import com.grabpt.dto.response.ChatResponse;
+import com.grabpt.dto.response.ChatRoomPreviewDto;
 import com.grabpt.repository.ChatRepository.UserChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
@@ -27,8 +29,8 @@ public class UserChatRoomServiceImpl implements UserChatRoomService{
 	}
 
 	@Override
-	public List<UserChatRoom> findByUserId(Long userId, String keyword) {
-		return userChatRoomRepository.findByUserId(userId, keyword);
+	public List<ChatRoomPreviewDto> findChatRoomPreviewsByUserId(Long userId, String keyword) {
+		return userChatRoomRepository.findChatRoomPreviewsByUserId(userId, keyword);
 	}
 
 	@Override

--- a/src/main/java/com/grabpt/service/ChatService/UserChatRoomServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/UserChatRoomServiceImpl.java
@@ -3,6 +3,7 @@ package com.grabpt.service.ChatService;
 import com.grabpt.domain.entity.UserChatRoom;
 import com.grabpt.repository.ChatRepository.UserChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,5 +40,10 @@ public class UserChatRoomServiceImpl implements UserChatRoomService{
 	public Optional<UserChatRoom> findByRoomIdAndUserId(Long roomId, Long userId) {
 		return userChatRoomRepository.findByRoomIdAndUserId(roomId, userId);
 	}
+
+	@Override
+	public List<Long> findChatRoomIdsByUserId(@Param("userId") Long userId){
+		return userChatRoomRepository.findChatRoomIdsByUserId(userId);
+	};
 
 }


### PR DESCRIPTION
## PR 제목
- [Refactor] 채팅방 입장 시 메시지 읽음 처리 성능 개선, [Refactor] 채팅방 리스트 조회 성능 개선


## 변경 사항
- 채팅방 입장 시, 여러 건의 메시지에 대해 읽음 처리 해야하는데 메시지 하나마다 쿼리가 발생하는 상황 
->벌크 업데이트 쿼리 사용을 통해 조회 성능 42%향상 (메시지 4개일 시)
- 채팅방 리스트 조회 시 converter에서 엔티티 연쇄 조회로 인한 대량 쿼리 발생
-> Dto projection을 통해 조회 속도 291ms->105ms로 개선 (채팅방 4개일 시)
## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #17

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
