### PR TITLE
[Refactor] 기존 회원 로그인 시 profile_image 반환, 요청서 및 제안서 관련 수정

### DIFF
--- a/src/main/java/com/grabpt/config/jwt/properties/CookieConstants.java
+++ b/src/main/java/com/grabpt/config/jwt/properties/CookieConstants.java
@@ -9,6 +9,7 @@ public final class CookieConstants {
 	// 사용자 정보 쿠키
 	public static final String ROLE = "role";
 	public static final String USER_ID = "userId";
+	public static final String PROFILE_IMAGE = "profileImage";
 
 	// OAuth 임시 정보 쿠키 (회원가입용)
 	public static final String OAUTH_EMAIL = "oauthEmail";

--- a/src/main/java/com/grabpt/config/jwt/properties/CookieManagerV2.java
+++ b/src/main/java/com/grabpt/config/jwt/properties/CookieManagerV2.java
@@ -110,6 +110,20 @@ public final class CookieManagerV2 {
 		addCookie(response, cookie);
 	}
 
+	/**
+	 * Profile Image 쿠키 설정 (프론트에서 읽을 수 있음)
+	 */
+	public static void setProfileImage(HttpServletResponse response, HttpServletRequest request, String profileImageUrl) {
+		EnvironmentProfile env = EnvironmentDetector.detectEnvironment(request);
+
+		ResponseCookie cookie = createCookie(env, PROFILE_IMAGE, urlEncode(profileImageUrl))
+			.httpOnly(false)
+			.maxAge(Duration.ofDays(30))
+			.path("/")
+			.build();
+		addCookie(response, cookie);
+	}
+
 	// ==================== OAuth 임시 정보 쿠키 ====================
 
 	/**

--- a/src/main/java/com/grabpt/config/oauth/handler/OAuth2SuccessHandlerImproved.java
+++ b/src/main/java/com/grabpt/config/oauth/handler/OAuth2SuccessHandlerImproved.java
@@ -92,6 +92,7 @@ public class OAuth2SuccessHandlerImproved implements AuthenticationSuccessHandle
 				.queryParam("refresh_token", refreshToken)
 				.queryParam("role", getRoleString(user.getRole()))
 				.queryParam("user_id", user.getId().toString())
+				.queryParam("profile_image", user.getProfileImageUrl())
 				.build()
 				.encode()  // ✅ URL 인코딩 추가!
 				.toUriString();
@@ -106,6 +107,7 @@ public class OAuth2SuccessHandlerImproved implements AuthenticationSuccessHandle
 			CookieManagerV2.setRefreshToken(response, request, refreshToken);
 			CookieManagerV2.setRole(response, request, getRoleString(user.getRole()));
 			CookieManagerV2.setUserId(response, request, user.getId().toString());
+			CookieManagerV2.setProfileImage(response, request, user.getProfileImageUrl());
 
 			String redirectUrl = UriComponentsBuilder.fromUriString(frontendBase)
 				.path("/authcallback")

--- a/src/main/java/com/grabpt/dto/response/RequestionResponseDto.java
+++ b/src/main/java/com/grabpt/dto/response/RequestionResponseDto.java
@@ -43,6 +43,9 @@ public class RequestionResponseDto {
 		private String userNickname;
 		private String profileImageUrl;
 
+		// 매칭 여부
+		private Boolean isMatched;
+
 		public static RequestionDetailResponseDto from(Requestions r) {
 			Users u = r.getUser();
 
@@ -63,6 +66,7 @@ public class RequestionResponseDto {
 				.etcPurposeContent(r.getEtcPurposeContent())
 				.userNickname(u.getNickname())
 				.profileImageUrl(u.getProfileImageUrl())
+				.isMatched(r.getMatching() != null)
 				.build();
 		}
 	}

--- a/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
+++ b/src/main/java/com/grabpt/dto/response/SuggestionResponseDto.java
@@ -25,7 +25,7 @@ public class SuggestionResponseDto {
 
 		private Integer suggestedPrice;
 		private Integer requestedPrice;
-		private Integer discountAmount; // = original - suggested
+		private Integer discountedPrice; // = original - suggested
 		private Boolean isDiscounted;   // true if discount exists
 
 		private String message;
@@ -37,7 +37,11 @@ public class SuggestionResponseDto {
 		private Long matchingId;
 		private Long requestionId;
 		private Long suggestionId;
-		private Long sessionCount; // 전문가가 제안한 총 횟수
+
+		// 세션 횟수 관련 상세 정보
+		private Integer suggestionSessionCount; // 전문가가 제안한 총 횟수
+		private Integer requestionSessionCount; // 요청서의 총 횟수
+		private Integer discountSessionCount;   // 횟수 차이 (요청 - 제안, 차이가 있을 경우)
 	}
 
 	@Getter

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -19,7 +19,6 @@ import com.grabpt.apiPayload.exception.handler.SuggestionHandler;
 import com.grabpt.apiPayload.exception.handler.UserHandler;
 import com.grabpt.aws.s3.AmazonS3Manager;
 import com.grabpt.aws.s3.Uuid;
-import com.grabpt.converter.SuggestionConverter;
 import com.grabpt.domain.entity.Matching;
 import com.grabpt.domain.entity.ProProfile;
 import com.grabpt.domain.entity.Requestions;
@@ -122,13 +121,20 @@ public class SuggestionServiceImpl implements SuggestionService {
 		Matching matching = matchingService.findMatchingBySuggestionId(suggestionId);
 		Long matchId = (matching != null) ? matching.getId() : null;
 
+		// 세션 횟수 관련 계산
+		Integer suggestionSessionCount = suggestion.getSessionCount();
+		Integer requestionSessionCount = requestion.getSessionCount();
+		Integer sessionDiff = (requestionSessionCount != null && suggestionSessionCount != null)
+			? requestionSessionCount - suggestionSessionCount
+			: null;
+
 		return SuggestionResponseDto.SuggestionDetailResponseDto.builder()
 			.userNickname(user.getNickname())
 			.centerName(pro.getCenter())
 			.profileImageUrl(user.getProfileImageUrl())
 			.suggestedPrice(suggestedPrice)
 			.requestedPrice(originalPrice)
-			.discountAmount(discount > 0 ? discount : 0)
+			.discountedPrice(discount > 0 ? discount : 0)
 			.isDiscounted(discount > 0)
 			.message(suggestion.getMessage())
 			.location(suggestion.getLocation())
@@ -138,7 +144,9 @@ public class SuggestionServiceImpl implements SuggestionService {
 			.matchingId(matchId)  // 매칭 ID (없으면 null)
 			.requestionId(requestion.getId())
 			.suggestionId(suggestionId)
-			.sessionCount(suggestion.getSessionCount() != null ? suggestion.getSessionCount().longValue() : null)
+			.suggestionSessionCount(suggestionSessionCount)
+			.requestionSessionCount(requestionSessionCount)
+			.discountSessionCount(sessionDiff != null && sessionDiff != 0 ? sessionDiff : null)
 			.build();
 	}
 

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -154,7 +155,7 @@ public class SuggestionServiceImpl implements SuggestionService {
 	@Transactional(readOnly = true)
 	public Page<SuggestionResponseDto.SuggestionResponsePagingDto> getSuggestionsByRequestionId(Long requestionId,
 		int page) {
-		Pageable pageable = PageRequest.of(page, 6); // 6개씩 페이징
+		Pageable pageable = PageRequest.of(page, 6, Sort.by(Sort.Direction.DESC, "createdAt")); // 6개씩 페이징, 최신순
 		Page<Suggestions> suggestionsPage = suggestionRepository.findByRequestionId(requestionId, pageable);
 
 		return suggestionsPage.map(s -> {

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -192,8 +192,8 @@ public class SuggestionServiceImpl implements SuggestionService {
 
 			return SuggestionResponseDto.MySuggestionPagingDto.builder()
 				.userNickname(s.getRequestion().getUser().getNickname())
-				.suggestedPrice(s.getRequestion().getPrice())
-				.sessionCount(s.getRequestion().getSessionCount())
+				.suggestedPrice(s.getPrice())
+				.sessionCount(s.getSessionCount())
 				.matchingStatus(status)
 				.requestionId(s.getRequestion().getId())
 				.suggestionId(s.getId())


### PR DESCRIPTION
## PR 제목
- [Refactor] 기존 회원 로그인 시 profile_image 반환, 요청서 및 제안서 관련 수정

## 변경 사항
- 기존 회원 로그인 시 AuthCallback 리다이렉트 수정 -> profile_image 추가
- /api/requestion/{requestionId} 여기에 매칭 여부 isMatched 추가
- /api/suggestion/{suggestionId}에서 suggestionSessionCount, requestionSessionCount, discountSessionCount 반환
- /api/suggestion/suggestion/suggestionList/{requestionId} 최신순으로 정렬 및 반환
- /api/suggestion/mySuggestions에서 suggestedPrice와 sessionCount를 전문가가 제안한 값으로 반환

## 작업 내용 체크
- build 확인

