### PR TITLE
[Fix] https://dev-grabpt.vercel.app 화이트리스트 추가

### DIFF
--- a/src/main/java/com/grabpt/config/jwt/CsrfOriginFilter.java
+++ b/src/main/java/com/grabpt/config/jwt/CsrfOriginFilter.java
@@ -23,7 +23,8 @@ public class CsrfOriginFilter extends OncePerRequestFilter {
 		"https://localhost:5173",
 		"http://localhost:3000",
 		"https://localhost:3000",
-		"https://grabpt-dev.vercel.app" // 프론트 개발 서버
+		"https://grabpt-dev.vercel.app",
+		"https://dev-grabpt.vercel.app" // 프론트 개발 서버
 	);
 
 	// 상태 변경만 검사 (OPTIONS는 프리플라이트라서 제외하는 편이 낫습니다)


### PR DESCRIPTION
## PR 제목
- [Fix] https://dev-grabpt.vercel.app 화이트리스트 추가

## 변경 사항
- https://dev-grabpt.vercel.app에서 실행 중인데, 이 도메인이 CsrfOriginFilter의 화이트리스트에 없어서 POST 요청 시 403이 발생

## 작업 내용 체크
- 빌드 확인