### PR TITLE
[Refactor] sms 인증 시 인증번호 재사용 방지 및 TTL 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,9 @@ dependencies {
     
     // ImPort 의존성
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
+
+    // Caffeine Cache
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grabpt/config/sms/SmsCertificationStorage.java
+++ b/src/main/java/com/grabpt/config/sms/SmsCertificationStorage.java
@@ -1,27 +1,34 @@
 package com.grabpt.config.sms;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Component;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 @Component
 public class SmsCertificationStorage {
-	// 전화번호 → 인증번호
-	private final ConcurrentHashMap<String, String> certificationMap = new ConcurrentHashMap<>();
+	// 전화번호 → 인증번호 (5분 TTL)
+	private final Cache<String, String> certificationCache = Caffeine.newBuilder()
+		.expireAfterWrite(5, TimeUnit.MINUTES)
+		.maximumSize(10000)
+		.build();
 
 	public void saveCertificationCode(String phoneNum, String code) {
-		certificationMap.put(phoneNum, code);
+		certificationCache.put(phoneNum, code);
 	}
 
 	public String getCertificationCode(String phoneNum) {
-		return certificationMap.get(phoneNum);
+		return certificationCache.getIfPresent(phoneNum);
 	}
 
 	public void removeCertificationCode(String phoneNum) {
-		certificationMap.remove(phoneNum);
+		certificationCache.invalidate(phoneNum);
 	}
 
 	public boolean verifyCode(String phoneNum, String inputCode) {
-		return inputCode.equals(certificationMap.get(phoneNum));
+		String savedCode = certificationCache.getIfPresent(phoneNum);
+		return inputCode != null && inputCode.equals(savedCode);
 	}
 }

--- a/src/main/java/com/grabpt/controller/SmsController.java
+++ b/src/main/java/com/grabpt/controller/SmsController.java
@@ -61,6 +61,7 @@ public class SmsController {
 	public ApiResponse<String> verifySms(@RequestBody SmsVerifyResponseDto dto) {
 		String savedCode = smsCertificationStorage.getCertificationCode(dto.getPhoneNumber());
 		if (savedCode != null && savedCode.equals(dto.getInputCode())) {
+			smsCertificationStorage.removeCertificationCode(dto.getPhoneNumber());
 			return ApiResponse.onSuccess("인증 성공");
 		} else {
 			throw new AuthHandler(ErrorStatus.UNAUTHORIZED_SMS);


### PR DESCRIPTION
## PR 제목
- [Refactor] sms 인증 시 인증번호 재사용 방지 및 TTL 설정

## 변경 사항
- 기존 재사용 가능한 인증번호와 TTL 미설정으로 메모리 누수 가능성이 있었던 문제 해결

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- https://github.com/grabPT/grabPT-backend/issues/453

