### PR TITLE
[Refactor, Feat] Requestion Status 수정 및 스케줄러 등록

### DIFF
--- a/src/main/java/com/grabpt/GrabptApplication.java
+++ b/src/main/java/com/grabpt/GrabptApplication.java
@@ -3,9 +3,11 @@ package com.grabpt;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class GrabptApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
@@ -60,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	MATCHING_ALREADY_CANCLED(HttpStatus.BAD_REQUEST, "REQ4004", "매칭이 이미 취소되었습니다."),
 	REQUESTION_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REQU4005", "매칭 진행/완료된 요청서는 삭제할 수 없습니다."),
 	REQUESTION_DELETE_NOT_OWNER(HttpStatus.FORBIDDEN, "REQU4006", "요청서 작성자만 삭제할 수 있습니다."),
+	REQUESTION_EXPIRED(HttpStatus.BAD_REQUEST, "REQU4007", "요청서가 만료되었습니다."),
 
 	/// 지원서 관련 오류
 	SUGGESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "SUGG4001", "존재하지 않는 지원서입니다."),

--- a/src/main/java/com/grabpt/config/RequestionScheduler.java
+++ b/src/main/java/com/grabpt/config/RequestionScheduler.java
@@ -1,0 +1,40 @@
+package com.grabpt.config;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grabpt.domain.enums.RequestStatus;
+import com.grabpt.repository.RequestionRepository.RequestionRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RequestionScheduler {
+
+	private final RequestionRepository requestionRepository;
+
+	/**
+	 * 매일 자정에 만료된 요청서를 CLOSED 상태로 변경
+	 */
+	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional
+	public void closeExpiredRequestions() {
+		log.info("[Scheduler] Starting to close expired requestions at {}", LocalDateTime.now());
+
+		List<RequestStatus> targetStatuses = List.of(RequestStatus.WAITING, RequestStatus.MATCHING);
+		int updatedCount = requestionRepository.bulkUpdateExpiredRequestions(
+			targetStatuses,
+			RequestStatus.CLOSED,
+			LocalDateTime.now()
+		);
+
+		log.info("[Scheduler] Closed {} expired requestions", updatedCount);
+	}
+}

--- a/src/main/java/com/grabpt/domain/entity/Requestions.java
+++ b/src/main/java/com/grabpt/domain/entity/Requestions.java
@@ -3,6 +3,7 @@ package com.grabpt.domain.entity;
 import static java.util.List.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -110,6 +111,16 @@ public class Requestions extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private RequestStatus status;
+
+	private LocalDateTime expiredAt;
+
+	public void extendExpiredAt() {
+		this.expiredAt = LocalDateTime.now().plusWeeks(1);
+	}
+
+	public boolean isExpired() {
+		return this.expiredAt != null && LocalDateTime.now().isAfter(this.expiredAt);
+	}
 
 	public void addSuggestion(Suggestions suggestion) {
 		this.suggestions.add(suggestion);

--- a/src/main/java/com/grabpt/domain/enums/RequestStatus.java
+++ b/src/main/java/com/grabpt/domain/enums/RequestStatus.java
@@ -1,5 +1,5 @@
 package com.grabpt.domain.enums;
 
 public enum RequestStatus {
-	MATCHING, MATCHED
+	WAITING, MATCHING, MATCHED, CLOSED
 }

--- a/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
+++ b/src/main/java/com/grabpt/repository/RequestionRepository/RequestionRepository.java
@@ -2,6 +2,7 @@ package com.grabpt.repository.RequestionRepository;
 
 import static jakarta.persistence.LockModeType.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,11 +10,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.grabpt.domain.entity.Category;
 import com.grabpt.domain.entity.Requestions;
+import com.grabpt.domain.enums.RequestStatus;
 
 public interface RequestionRepository extends JpaRepository<Requestions, Long> {
 	Page<Requestions> findAllByUserId(Long userId, Pageable pageable);
@@ -69,5 +72,18 @@ public interface RequestionRepository extends JpaRepository<Requestions, Long> {
 	long countByCategoryAndRegion(
 		@Param("categoryName") String categoryName,
 		@Param("fullRegion") String fullRegion
+	);
+
+	@Modifying
+	@Query("""
+		UPDATE Requestions r
+		SET r.status = :newStatus
+		WHERE r.status IN :currentStatuses
+		  AND r.expiredAt < :now
+		""")
+	int bulkUpdateExpiredRequestions(
+		@Param("currentStatuses") List<RequestStatus> currentStatuses,
+		@Param("newStatus") RequestStatus newStatus,
+		@Param("now") LocalDateTime now
 	);
 }

--- a/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
+++ b/src/main/java/com/grabpt/service/MatchingService/MatchingServiceImpl.java
@@ -52,10 +52,16 @@ public class MatchingServiceImpl implements MatchingService {
 			requestion.getStatus(),
 			requestion.getStatus() != null ? requestion.getStatus().name() : "null");
 
-		// 2) 매칭 가능 상태만 허용
-		if (requestion.getStatus() != RequestStatus.MATCHING) {
-			log.warn("[MATCH] BLOCK: status is not MATCHING. actual={}", requestion.getStatus());
+		// 2) 매칭 가능 상태만 허용 (WAITING 또는 MATCHING)
+		if (requestion.getStatus() != RequestStatus.WAITING && requestion.getStatus() != RequestStatus.MATCHING) {
+			log.warn("[MATCH] BLOCK: status is not WAITING or MATCHING. actual={}", requestion.getStatus());
 			throw new RequestionHandler(ErrorStatus.REQUESTION_ALREADY_MATCHED);
+		}
+
+		// 만료 체크
+		if (requestion.isExpired()) {
+			log.warn("[MATCH] BLOCK: requestion is expired. expiredAt={}", requestion.getExpiredAt());
+			throw new RequestionHandler(ErrorStatus.REQUESTION_EXPIRED);
 		}
 
 		// 3) 제안서 로드 + 연결 검증
@@ -122,9 +128,11 @@ public class MatchingServiceImpl implements MatchingService {
 
 		matching.setStatus(newStatus);
 
-		if (newStatus == MatchingStatus.CANCELLED || newStatus == MatchingStatus.COMPLETED) {
+		if (newStatus == MatchingStatus.CANCELLED) {
 			Requestions requestion = matching.getRequestion();
-			requestion.setStatus(RequestStatus.MATCHING);
+			// 제안서 유무에 따라 WAITING/MATCHING 복원
+			boolean hasSuggestions = requestion.getSuggestions() != null && !requestion.getSuggestions().isEmpty();
+			requestion.setStatus(hasSuggestions ? RequestStatus.MATCHING : RequestStatus.WAITING);
 			requestionRepository.save(requestion);
 		}
 

--- a/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/RequestionService/RequestionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.grabpt.service.RequestionService;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -73,7 +74,8 @@ public class RequestionServiceImpl implements RequestionService {
 			.etcPurposeContent(dto.getEtcPurposeContent())
 			.content(dto.getContent())
 			.location(dto.getLocation())
-			.status(RequestStatus.MATCHING)
+			.status(RequestStatus.WAITING)
+			.expiredAt(LocalDateTime.now().plusWeeks(1))
 			.build();
 		requestion.setUser(user); // 연관관계 설정
 		Requestions save = requestionRepository.save(requestion);
@@ -184,8 +186,8 @@ public class RequestionServiceImpl implements RequestionService {
 			throw new RequestionHandler(ErrorStatus.REQUESTION_DELETE_NOT_OWNER);
 		}
 
-		// 상태 검사: MATCHING(= 미매칭 상태)일 때만 삭제 허용
-		if (requestion.getStatus() != RequestStatus.MATCHING) {
+		// 상태 검사: WAITING 또는 MATCHING일 때만 삭제 허용
+		if (requestion.getStatus() != RequestStatus.WAITING && requestion.getStatus() != RequestStatus.MATCHING) {
 			throw new RequestionHandler(ErrorStatus.REQUESTION_DELETE_NOT_ALLOWED);
 		}
 

--- a/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
+++ b/src/main/java/com/grabpt/service/SuggestionService/SuggestionServiceImpl.java
@@ -27,6 +27,7 @@ import com.grabpt.domain.entity.SuggestionPhoto;
 import com.grabpt.domain.entity.Suggestions;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.MatchingStatus;
+import com.grabpt.domain.enums.RequestStatus;
 import com.grabpt.domain.enums.SuggestStatus;
 import com.grabpt.dto.request.SuggestionRequestDto;
 import com.grabpt.dto.response.SuggestionResponseDto;
@@ -75,6 +76,12 @@ public class SuggestionServiceImpl implements SuggestionService {
 
 		suggestion.setProProfile(proProfile);
 		suggestion.setRequestion(requestion);
+
+		// WAITING → MATCHING 전환 및 expiredAt 연장
+		if (requestion.getStatus() == RequestStatus.WAITING) {
+			requestion.setStatus(RequestStatus.MATCHING);
+		}
+		requestion.extendExpiredAt();
 
 		// S3 업로드 및 SuggestionPhoto 저장
 		if (photos != null && !photos.isEmpty()) {


### PR DESCRIPTION
## PR 제목
- [Refactor] RequestStatus에 WAITING/CLOSED 추가 및 요청서 만료 필드 정의
- [Refactor] 요청서 상태 흐름에 WAITING 단계 도입 및 만료 체크 적용
- [Feat] 만료된 요청서 자동 CLOSED 처리 스케줄러 추가                                                                                                                                  

## 변경 사항
- RequestStatus - WAITING, CLOSED enum 추가
- Requestions.java - expiredAt 필드, extendExpiredAt(), isExpired() 추가
- ErrorStatus.java - REQUESTION_EXPIRED 에러코드 추가
- RequestionServiceImpl.java - 생성 시 초기 status WAITING, expiredAt 설정, 삭제 조건 수정
- SuggestionServiceImpl.java - 제안서 등록 시 WAITING → MATCHING 전환 + expiredAt 연장
- MatchingServiceImpl.java - 매칭 시 WAITING 허용, 만료 체크, 취소 시 상태 복원 로직 개선
-  GrabptApplication.java - @EnableScheduling 추가
- RequestionScheduler.java - 매일 자정 만료 요청서 CLOSED 처리 (신규)
- RequestionRepository.java - bulkUpdateExpiredRequestions 벌크 업데이트 쿼리 추가

## 작업 내용 체크
- 기능 동작 확인

