### PR TITLE
[Feat] 계약 내역 목록 조회 API 추가 (GET /contract/list)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs grep:*)"
+    ]
+  }
+}

--- a/src/main/java/com/grabpt/controller/ContractController.java
+++ b/src/main/java/com/grabpt/controller/ContractController.java
@@ -4,12 +4,15 @@ import com.grabpt.service.ContractService.ContractPhotoServiceImpl;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import com.grabpt.apiPayload.ApiResponse;
 import com.grabpt.converter.ContractConverter;
 import com.grabpt.domain.entity.Contract;
+import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.ContractRequest;
 import com.grabpt.dto.response.ContractResponse;
 import com.grabpt.service.ContractService.ContractService;
@@ -24,6 +27,21 @@ public class ContractController {
 
 	private final ContractService contractService;
 	private final ContractPhotoServiceImpl contractPhotoService;
+
+	@Operation(
+		summary = "계약 내역 목록 조회 API",
+		description = "role(USER/PRO)과 userId를 기반으로 계약 목록을 조회합니다. " +
+			"USER 조회 시 상대방(전문가) 정보, PRO 조회 시 상대방(회원) 정보를 반환합니다."
+	)
+	@GetMapping("/contract/list")
+	public ApiResponse<ContractResponse.ContractListResponseDto> getContractList(
+		@RequestParam Role role,
+		@RequestParam Long userId,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+		return ApiResponse.onSuccess(contractService.getContractList(role, userId, pageable));
+	}
 
 	@Operation(
 		description = "계약서 Id를 통해 계약서에 대한 정보를 조회합니다",

--- a/src/main/java/com/grabpt/dto/response/ContractResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ContractResponse.java
@@ -9,6 +9,7 @@ import com.grabpt.domain.enums.MatchingStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 public class ContractResponse {
 
@@ -56,5 +57,45 @@ public class ContractResponse {
 
 		@Schema(description = "계약 ID", example = "555")
 		Long contractId;
+	}
+
+	@Getter
+	@Builder
+	public static class ContractListResponseDto {
+		@Schema(description = "진행 중인 계약 수 (MATCHED)", example = "2")
+		Integer totalActiveContracts;
+
+		@Schema(description = "완료된 계약 수 (COMPLETED)", example = "5")
+		Integer totalCompletedContracts;
+
+		@Schema(description = "계약 목록 (페이지)")
+		Page<ContractListItemDto> contracts;
+	}
+
+	@Getter
+	@Builder
+	public static class ContractListItemDto {
+		@Schema(description = "상대방 닉네임 (회원 조회 시 전문가 닉네임, 전문가 조회 시 회원 닉네임)", example = "운동초보냥")
+		String userNickname;
+
+		@Schema(description = "상대방 프로필 이미지 URL", example = "https://grabpt.com/images/default.png")
+		String profileImageUrl;
+
+		@Schema(description = "매칭 상태 (MATCHED: 진행중, COMPLETED: 결제완료)", example = "MATCHED")
+		MatchingStatus matchingStatus;
+
+		@Schema(description = "총 세션 횟수", example = "20")
+		Integer sessionCount;
+
+		@Schema(description = "1회 계약 금액(원)", example = "45000")
+		Integer contractPrice;
+
+		@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+		@Schema(description = "시작일", example = "2024-03-01")
+		LocalDate startDate;
+
+		@JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+		@Schema(description = "만료일", example = "2024-05-31")
+		LocalDate expireDate;
 	}
 }

--- a/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
+++ b/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
@@ -3,6 +3,8 @@ package com.grabpt.repository.MatchingRepository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -52,5 +54,41 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 		    where m.requestion.id in :requestionIds
 		""")
 	List<Matching> findAllWithProByRequestionIds(@Param("requestionIds") List<Long> requestionIds);
+
+	// 계약 목록 조회 - 회원(USER) 기준
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.requestion req
+		    WHERE req.user.id = :userId
+		      AND m.status IN :statuses
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByUserId(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 계약 목록 조회 - 전문가(PRO) 기준
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
+		    WHERE pp.user.id = :userId
+		      AND m.status IN :statuses
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByProUserId(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 카운트 - 회원(USER) 기준, 복수 상태
+	Long countByRequestion_User_IdAndStatusIn(Long userId, List<MatchingStatus> statuses);
+
+	// 카운트 - 전문가(PRO) 기준, 복수 상태
+	@Query("""
+		    SELECT COUNT(m) FROM Matching m
+		    JOIN m.suggestion sug
+		    WHERE sug.proProfile.user.id = :userId
+		      AND m.status IN :statuses
+		""")
+	Long countContractsByProUserIdAndStatuses(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses);
 
 }

--- a/src/main/java/com/grabpt/service/ContractService/ContractService.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractService.java
@@ -1,7 +1,10 @@
 package com.grabpt.service.ContractService;
 
 import com.grabpt.domain.entity.*;
+import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.ContractRequest;
+import com.grabpt.dto.response.ContractResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface ContractService{
 	public Contract createContract(Matching matching, Requestions req, Suggestions sug);
@@ -9,5 +12,6 @@ public interface ContractService{
 	public Contract writeProInfo(Long contractId, ContractRequest.ContractInfoForProDto request);
 	public Contract findById(Long contractId);
 	public String generateAndSavePdfToS3(Long contractId);
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, Pageable pageable);
 }
 

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -6,6 +6,10 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.TemplateEngine;
@@ -20,10 +24,14 @@ import com.grabpt.domain.entity.ContractInfo;
 import com.grabpt.domain.entity.Matching;
 import com.grabpt.domain.entity.Requestions;
 import com.grabpt.domain.entity.Suggestions;
+import com.grabpt.domain.entity.Users;
 import com.grabpt.domain.enums.Gender;
 import com.grabpt.domain.enums.MatchingStatus;
+import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.ContractRequest;
+import com.grabpt.dto.response.ContractResponse;
 import com.grabpt.repository.ContractRepository.ContractRepository;
+import com.grabpt.repository.MatchingRepository.MatchingRepository;
 import com.grabpt.service.AlarmService.AlarmService;
 import com.grabpt.service.PdfService.PdfGenerateService;
 
@@ -35,11 +43,19 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ContractServiceImpl implements ContractService {
 	private final ContractRepository contractRepository;
+	private final MatchingRepository matchingRepository;
 	private final AlarmService alarmService;
 	private final PdfGenerateService pdfGenerateService;
 	private final TemplateEngine templateEngine;
 	private final AmazonS3Manager amazonS3Manager;
 	private final AmazonConfig amazonConfig;
+
+	private static final List<MatchingStatus> ACTIVE_STATUSES =
+		List.of(MatchingStatus.MATCHED, MatchingStatus.USERWROTE);
+	private static final List<MatchingStatus> COMPLETED_STATUSES =
+		List.of(MatchingStatus.COMPLETED);
+	private static final List<MatchingStatus> ALL_CONTRACT_STATUSES =
+		List.of(MatchingStatus.MATCHED, MatchingStatus.USERWROTE, MatchingStatus.COMPLETED);
 
 	@Override
 	@Transactional
@@ -105,6 +121,62 @@ public class ContractServiceImpl implements ContractService {
 	public Contract findById(Long contractId) {
 		return contractRepository.findById(contractId)
 			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, Pageable pageable) {
+		Page<Matching> matchings;
+		long totalActive;
+		long totalCompleted;
+
+		if (role == Role.USER) {
+			matchings = matchingRepository.findContractsByUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+			totalActive = matchingRepository.countByRequestion_User_IdAndStatusIn(userId, ACTIVE_STATUSES);
+			totalCompleted = matchingRepository.countByRequestion_User_IdAndStatusIn(userId, COMPLETED_STATUSES);
+		} else {
+			matchings = matchingRepository.findContractsByProUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+			totalActive = matchingRepository.countContractsByProUserIdAndStatuses(userId, ACTIVE_STATUSES);
+			totalCompleted = matchingRepository.countContractsByProUserIdAndStatuses(userId, COMPLETED_STATUSES);
+		}
+
+		Page<ContractResponse.ContractListItemDto> items = matchings.map(m -> toContractListItem(m, role));
+
+		return ContractResponse.ContractListResponseDto.builder()
+			.totalActiveContracts((int) totalActive)
+			.totalCompletedContracts((int) totalCompleted)
+			.contracts(items)
+			.build();
+	}
+
+	private ContractResponse.ContractListItemDto toContractListItem(Matching matching, Role role) {
+		String nickname;
+		String profileImageUrl;
+
+		if (role == Role.USER) {
+			Users proUser = matching.getSuggestion().getProProfile().getUser();
+			nickname = proUser.getNickname();
+			profileImageUrl = proUser.getProfileImageUrl();
+		} else {
+			Users userEntity = matching.getRequestion().getUser();
+			nickname = userEntity.getNickname();
+			profileImageUrl = userEntity.getProfileImageUrl();
+		}
+
+		Contract contract = matching.getContract();
+		MatchingStatus displayStatus = (matching.getStatus() == MatchingStatus.COMPLETED)
+			? MatchingStatus.COMPLETED
+			: MatchingStatus.MATCHED;
+
+		return ContractResponse.ContractListItemDto.builder()
+			.userNickname(nickname)
+			.profileImageUrl(profileImageUrl)
+			.matchingStatus(displayStatus)
+			.sessionCount(contract != null ? contract.getTotalSession() : null)
+			.contractPrice(contract != null ? contract.getPrice() : null)
+			.startDate(contract != null ? contract.getStartDate() : null)
+			.expireDate(contract != null ? contract.getContractDate() : null)
+			.build();
 	}
 
 	@Transactional


### PR DESCRIPTION
## PR 제목
- [Feat] 계약 내역 목록 조회 API 추가 (GET /contract/list)

## 변경 사항
  - GET /contract/list 엔드포인트 추가 (role/userId 기반 페이징 조회) 
  - ContractListResponseDto, ContractListItemDto DTO 추가 
  - USER/PRO별 상대방 정보 반환 로직 구현
  - MatchingRepository 계약 목록/카운트 쿼리 추가
                                                  

## 작업 내용 체크
- 기능 동작 확인

