### PR TITLE
[Feat] 계약 목록 조회 API 응답 및 필터 개선 (GET /contract/list)

### DIFF
--- a/src/main/java/com/grabpt/controller/ContractController.java
+++ b/src/main/java/com/grabpt/controller/ContractController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import com.grabpt.apiPayload.ApiResponse;
 import com.grabpt.converter.ContractConverter;
 import com.grabpt.domain.entity.Contract;
+import com.grabpt.domain.enums.PaymentStatus;
 import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.ContractRequest;
 import com.grabpt.dto.response.ContractResponse;
@@ -37,10 +38,11 @@ public class ContractController {
 	public ApiResponse<ContractResponse.ContractListResponseDto> getContractList(
 		@RequestParam Role role,
 		@RequestParam Long userId,
+		@RequestParam(required = false) PaymentStatus paymentStatus,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size) {
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
-		return ApiResponse.onSuccess(contractService.getContractList(role, userId, pageable));
+		return ApiResponse.onSuccess(contractService.getContractList(role, userId, paymentStatus, pageable));
 	}
 
 	@Operation(

--- a/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
+++ b/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.grabpt.domain.entity.Matching;
 import com.grabpt.domain.enums.MatchingStatus;
+import com.grabpt.domain.enums.PaymentStatus;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	/** 트레이너 활성 회원 수 */
@@ -90,5 +91,103 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 		""")
 	Long countContractsByProUserIdAndStatuses(@Param("userId") Long userId,
 		@Param("statuses") List<MatchingStatus> statuses);
+
+	// 목록 조회 - 회원(USER) 기준, PaymentStatus.OK인 Order가 존재하는 매칭
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.requestion req
+		    WHERE req.user.id = :userId
+		      AND m.status IN :statuses
+		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByUserIdAndPaymentStatusOK(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 목록 조회 - 회원(USER) 기준, PaymentStatus.OK인 Order가 없는 매칭 (= READY)
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.requestion req
+		    WHERE req.user.id = :userId
+		      AND m.status IN :statuses
+		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByUserIdAndPaymentStatusReady(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 목록 조회 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 존재하는 매칭
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
+		    WHERE pp.user.id = :userId
+		      AND m.status IN :statuses
+		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByProUserIdAndPaymentStatusOK(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 목록 조회 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 없는 매칭 (= READY)
+	@Query("""
+		    SELECT m FROM Matching m
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
+		    WHERE pp.user.id = :userId
+		      AND m.status IN :statuses
+		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
+		    ORDER BY m.matchedAt DESC
+		""")
+	Page<Matching> findContractsByProUserIdAndPaymentStatusReady(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+
+	// 카운트 - 회원(USER) 기준, PaymentStatus.OK인 Order가 존재하는 매칭 수
+	@Query("""
+		    SELECT COUNT(DISTINCT m.id) FROM Matching m
+		    JOIN m.requestion req
+		    WHERE req.user.id = :userId
+		      AND m.status IN :statuses
+		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = :paymentStatus)
+		""")
+	Long countContractsByUserIdAndPaymentStatus(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("paymentStatus") PaymentStatus paymentStatus);
+
+	// 카운트 - 회원(USER) 기준, PaymentStatus.OK인 Order가 없는 매칭 수 (= READY)
+	@Query("""
+		    SELECT COUNT(DISTINCT m.id) FROM Matching m
+		    JOIN m.requestion req
+		    WHERE req.user.id = :userId
+		      AND m.status IN :statuses
+		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = :paymentStatus)
+		""")
+	Long countContractsByUserIdAndNotPaymentStatus(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("paymentStatus") PaymentStatus paymentStatus);
+
+	// 카운트 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 존재하는 매칭 수
+	@Query("""
+		    SELECT COUNT(DISTINCT m.id) FROM Matching m
+		    JOIN m.suggestion sug
+		    WHERE sug.proProfile.user.id = :userId
+		      AND m.status IN :statuses
+		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = :paymentStatus)
+		""")
+	Long countContractsByProUserIdAndPaymentStatus(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("paymentStatus") PaymentStatus paymentStatus);
+
+	// 카운트 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 없는 매칭 수 (= READY)
+	@Query("""
+		    SELECT COUNT(DISTINCT m.id) FROM Matching m
+		    JOIN m.suggestion sug
+		    WHERE sug.proProfile.user.id = :userId
+		      AND m.status IN :statuses
+		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = :paymentStatus)
+		""")
+	Long countContractsByProUserIdAndNotPaymentStatus(@Param("userId") Long userId,
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("paymentStatus") PaymentStatus paymentStatus);
 
 }

--- a/src/main/java/com/grabpt/service/ContractService/ContractService.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractService.java
@@ -1,6 +1,7 @@
 package com.grabpt.service.ContractService;
 
 import com.grabpt.domain.entity.*;
+import com.grabpt.domain.enums.PaymentStatus;
 import com.grabpt.domain.enums.Role;
 import com.grabpt.dto.request.ContractRequest;
 import com.grabpt.dto.response.ContractResponse;
@@ -12,6 +13,6 @@ public interface ContractService{
 	public Contract writeProInfo(Long contractId, ContractRequest.ContractInfoForProDto request);
 	public Contract findById(Long contractId);
 	public String generateAndSavePdfToS3(Long contractId);
-	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, Pageable pageable);
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, Pageable pageable);
 }
 

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -51,10 +51,6 @@ public class ContractServiceImpl implements ContractService {
 	private final AmazonS3Manager amazonS3Manager;
 	private final AmazonConfig amazonConfig;
 
-	private static final List<MatchingStatus> ACTIVE_STATUSES =
-		List.of(MatchingStatus.MATCHED, MatchingStatus.USERWROTE);
-	private static final List<MatchingStatus> COMPLETED_STATUSES =
-		List.of(MatchingStatus.COMPLETED);
 	private static final List<MatchingStatus> ALL_CONTRACT_STATUSES =
 		List.of(MatchingStatus.MATCHED, MatchingStatus.USERWROTE, MatchingStatus.COMPLETED);
 
@@ -126,19 +122,31 @@ public class ContractServiceImpl implements ContractService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, Pageable pageable) {
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, Pageable pageable) {
 		Page<Matching> matchings;
 		long totalActive;
 		long totalCompleted;
 
 		if (role == Role.USER) {
-			matchings = matchingRepository.findContractsByUserId(userId, ALL_CONTRACT_STATUSES, pageable);
-			totalActive = matchingRepository.countByRequestion_User_IdAndStatusIn(userId, ACTIVE_STATUSES);
-			totalCompleted = matchingRepository.countByRequestion_User_IdAndStatusIn(userId, COMPLETED_STATUSES);
+			if (paymentStatus == PaymentStatus.OK) {
+				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, pageable);
+			} else if (paymentStatus == PaymentStatus.READY) {
+				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, pageable);
+			} else {
+				matchings = matchingRepository.findContractsByUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+			}
+			totalActive = matchingRepository.countContractsByUserIdAndNotPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
+			totalCompleted = matchingRepository.countContractsByUserIdAndPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
 		} else {
-			matchings = matchingRepository.findContractsByProUserId(userId, ALL_CONTRACT_STATUSES, pageable);
-			totalActive = matchingRepository.countContractsByProUserIdAndStatuses(userId, ACTIVE_STATUSES);
-			totalCompleted = matchingRepository.countContractsByProUserIdAndStatuses(userId, COMPLETED_STATUSES);
+			if (paymentStatus == PaymentStatus.OK) {
+				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, pageable);
+			} else if (paymentStatus == PaymentStatus.READY) {
+				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, pageable);
+			} else {
+				matchings = matchingRepository.findContractsByProUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+			}
+			totalActive = matchingRepository.countContractsByProUserIdAndNotPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
+			totalCompleted = matchingRepository.countContractsByProUserIdAndPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
 		}
 
 		Page<ContractResponse.ContractListItemDto> items = matchings.map(m -> toContractListItem(m, role));


### PR DESCRIPTION
## PR 제목
- [Feat] 계약 목록 조회 API 응답 및 필터 개선 (GET /contract/list)

## 변경 사항
- ContractListItemDto에 contractId 추가, matchingStatus → paymentStatus(PaymentStatus) 변경
- paymentStatus 선택적 요청 파라미터 추가
- getContractList 시그니처에 paymentStatus 파라미터 추가 
- paymentStatus 기준 목록 필터 분기 처리, totalActiveContracts/totalCompletedContracts 집계 기준을 MatchingStatus → PaymentStatus로 변경
- paymentStatus 기준 목록 조회 쿼리 4개, 카운트 쿼리 4개 추가

## 작업 내용 체크
- 기능 동작 확인
