### PR TITLE
[Refactor] PdfGenerateService Playwright 인스턴스 재사용 구조로 개선

### DIFF
--- a/src/main/java/com/grabpt/service/PdfService/PdfGenerateService.java
+++ b/src/main/java/com/grabpt/service/PdfService/PdfGenerateService.java
@@ -1,43 +1,75 @@
 package com.grabpt.service.PdfService;
 
 
-import com.microsoft.playwright.Browser;
-import com.microsoft.playwright.Page;
-import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.*;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+@Slf4j
 @Service
 public class PdfGenerateService {
 
+	private Playwright playwright;
+	private Browser browser;
+	// PDF 생성을 순차적으로 처리하거나, 브라우저 스레드 안전성을 보장하기 위한 단일 스레드 실행자
+	private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+	@PostConstruct
+	public void init() {
+		executorService.submit(() -> {
+			try {
+				log.info("Playwright 및 브라우저 인스턴스 초기화 시작..");
+				playwright = Playwright.create();
+				browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+				log.info("Playwright 브라우저 초기화 완료");
+			} catch (Exception e) {
+				log.error("Playwright 초기화 실패");
+			}
+		});
+	}
+
+	@PreDestroy
+	public void cleanup() {
+		executorService.submit(() -> {
+			if(browser != null) {browser.close();}
+			if(playwright != null) {playwright.close();}
+		});
+		executorService.shutdown();
+	}
+
 	public ByteArrayInputStream generatePdfFromHtml(String htmlContent) throws IOException {
-		try (Playwright playwright = Playwright.create()) {
-			// Chromium 브라우저 인스턴스 실행
-			Browser browser = playwright.chromium().launch();
-			Page page = browser.newPage();
-
-			// 페이지에 HTML 컨텐츠 설정
-			page.setContent(htmlContent);
-
-			// PDF 생성 옵션 설정 (A4 사이즈)
-			Page.PdfOptions pdfOptions = new Page.PdfOptions()
-				.setFormat("A4")
-				.setPrintBackground(true); // 배경 그래픽 인쇄
-
-			// HTML을 PDF로 변환하여 byte 배열로 저장
-			byte[] pdfBytes = page.pdf(pdfOptions);
-
-			// 브라우저 종료
-			browser.close();
-
-			// 생성된 PDF byte 배열을 InputStream으로 변환하여 반환
-			return new ByteArrayInputStream(pdfBytes);
-		} catch (Exception e) {
-			// 예외 발생 시 IOException으로 감싸서 던지기
-			throw new IOException("Playwright를 사용하여 PDF를 생성하는 중 오류 발생", e);
+		if(browser == null){
+			throw new IOException("PDF 엔진이 아직 준비되지 않았습니다.");
 		}
+
+		try {
+			byte[] pdfBytes = CompletableFuture.supplyAsync(() -> {
+				try(BrowserContext context = browser.newContext()) {
+					Page page = context.newPage();
+					page.setContent(htmlContent);
+
+					Page.PdfOptions pdfOptions = new Page.PdfOptions()
+						.setFormat("A4")
+						.setPrintBackground(true);
+
+					return page.pdf(pdfOptions);
+				}
+			}, executorService).get();
+
+			return new ByteArrayInputStream(pdfBytes);
+		}  catch (Exception e) {
+			log.error("PDF 생성 중 오류 발생",e);
+			throw new IOException("PDF 변환 실패",e);
+		}
+
 	}
 }


### PR DESCRIPTION
## PR 제목
- [Refactor] PdfGenerateService Playwright 인스턴스 재사용 구조로 개선

## 변경 사항
- Playwright 및 Browser 인스턴스를 매 요청마다 생성/종료하던 방식에서 @PostConstruct/@PreDestroy를 활용한 싱글턴 라이프사이클로 변경
- SingleThreadExecutor를 도입하여 브라우저 스레드 안전성 보장 및 PDF 생성 요청의 순차 처리 보장
- BrowserContext를 요청 단위로 생성/해제하여 페이지 격리 유지
- CompletableFuture.supplyAsync를 통해 전용 스레드에서 PDF 생성 수행
- 브라우저 미초기화 시 예외 처리 및 Slf4j 로깅 추가

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #101 

## 기타 공유 사항
- 로컬에서 확인하였을 때는 매우 빠른 속도를 보여주었으나, 서버(배포) 환경에서 실제 기대값은 확인해봐야 합니다.