### PR TITLE
[Feat, Refactor] 결제 로직 수정, 계약서 삭제, 계약서 목록 닉네임 검색

### DIFF
--- a/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	/// 계약서 관련 오류
 	CONTRACT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CONT4001", "계약이 존재하지 않습니다"),
+	CONTRACT_DELETE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "CONT4031", "계약서 삭제 권한이 없습니다"),
 
 	/// 이미지 관련 오류
 	NOT_IMAGE(HttpStatus.BAD_REQUEST, "IMG4001", "이미지가 없습니다."),

--- a/src/main/java/com/grabpt/config/SecurityConfig.java
+++ b/src/main/java/com/grabpt/config/SecurityConfig.java
@@ -119,6 +119,7 @@ public class SecurityConfig {
 					"/api/auth/**",
 					"/matching/**",
 					"/payment/**",
+					"/paymentCallback",
 					"/api/sms/**",
 					"/api/category-proprofile/**",
 					"/api/*/reviews",

--- a/src/main/java/com/grabpt/controller/ContractController.java
+++ b/src/main/java/com/grabpt/controller/ContractController.java
@@ -40,10 +40,11 @@ public class ContractController {
 		@RequestParam Role role,
 		@RequestParam Long userId,
 		@RequestParam(required = false) PaymentStatus paymentStatus,
+		@RequestParam(required = false) String nickname,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size) {
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
-		return ApiResponse.onSuccess(contractService.getContractList(role, userId, paymentStatus, pageable));
+		return ApiResponse.onSuccess(contractService.getContractList(role, userId, paymentStatus, nickname, pageable));
 	}
 
 	@Operation(

--- a/src/main/java/com/grabpt/controller/ContractController.java
+++ b/src/main/java/com/grabpt/controller/ContractController.java
@@ -1,5 +1,6 @@
 package com.grabpt.controller;
 
+import com.grabpt.config.SecurityUtils;
 import com.grabpt.service.ContractService.ContractPhotoServiceImpl;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -154,6 +155,23 @@ public class ContractController {
 	public ApiResponse<String> uploadProSign(@PathVariable(name = "contractId") Long contractId, @RequestPart MultipartFile file) {
 		contractPhotoService.uploadProSign(contractId,file);
 		return ApiResponse.onSuccess("전문가 전자서명 upload");
+	}
+
+	@Operation(
+		summary = "계약서 삭제 API",
+		description = "계약서 ID를 받아 해당 계약서 + 연결된 요청서 + 해당 요청서의 모든 제안서를 삭제합니다. 요청서 작성자(수강생)만 삭제 가능합니다."
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CONTRACT_NOT_FOUND"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+	})
+	@DeleteMapping("/contract/{contractId}")
+	public ApiResponse<Void> deleteContract(@PathVariable(name = "contractId") Long contractId) {
+		String email = SecurityUtils.currentUserOrThrow().getUser().getEmail();
+		contractService.deleteContract(contractId, email);
+		return ApiResponse.onSuccess(null);
 	}
 
 }

--- a/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
+++ b/src/main/java/com/grabpt/repository/MatchingRepository/MatchingRepository.java
@@ -60,24 +60,33 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.requestion req
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
 		    WHERE req.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR pp.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByUserId(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 계약 목록 조회 - 전문가(PRO) 기준
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.suggestion sug
 		    JOIN sug.proProfile pp
+		    JOIN m.requestion req
 		    WHERE pp.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR req.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByProUserId(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 카운트 - 회원(USER) 기준, 복수 상태
 	Long countByRequestion_User_IdAndStatusIn(Long userId, List<MatchingStatus> statuses);
@@ -96,51 +105,69 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.requestion req
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
 		    WHERE req.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR pp.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByUserIdAndPaymentStatusOK(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 목록 조회 - 회원(USER) 기준, PaymentStatus.OK인 Order가 없는 매칭 (= READY)
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.requestion req
+		    JOIN m.suggestion sug
+		    JOIN sug.proProfile pp
 		    WHERE req.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR pp.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByUserIdAndPaymentStatusReady(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 목록 조회 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 존재하는 매칭
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.suggestion sug
 		    JOIN sug.proProfile pp
+		    JOIN m.requestion req
 		    WHERE pp.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR req.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		      AND EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByProUserIdAndPaymentStatusOK(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 목록 조회 - 전문가(PRO) 기준, PaymentStatus.OK인 Order가 없는 매칭 (= READY)
 	@Query("""
 		    SELECT m FROM Matching m
 		    JOIN m.suggestion sug
 		    JOIN sug.proProfile pp
+		    JOIN m.requestion req
 		    WHERE pp.user.id = :userId
 		      AND m.status IN :statuses
+		      AND (:nickname IS NULL OR req.user.nickname LIKE CONCAT('%', :nickname, '%'))
 		      AND NOT EXISTS (SELECT o FROM m.orders o WHERE o.payment IS NOT NULL AND o.payment.status = com.grabpt.domain.enums.PaymentStatus.OK)
 		    ORDER BY m.matchedAt DESC
 		""")
 	Page<Matching> findContractsByProUserIdAndPaymentStatusReady(@Param("userId") Long userId,
-		@Param("statuses") List<MatchingStatus> statuses, Pageable pageable);
+		@Param("statuses") List<MatchingStatus> statuses,
+		@Param("nickname") String nickname,
+		Pageable pageable);
 
 	// 카운트 - 회원(USER) 기준, PaymentStatus.OK인 Order가 존재하는 매칭 수
 	@Query("""

--- a/src/main/java/com/grabpt/service/ContractService/ContractService.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractService.java
@@ -13,7 +13,7 @@ public interface ContractService{
 	public Contract writeProInfo(Long contractId, ContractRequest.ContractInfoForProDto request);
 	public Contract findById(Long contractId);
 	public String generateAndSavePdfToS3(Long contractId);
-	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, Pageable pageable);
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, String nickname, Pageable pageable);
 	public void deleteContract(Long contractId, String email);
 }
 

--- a/src/main/java/com/grabpt/service/ContractService/ContractService.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractService.java
@@ -14,5 +14,6 @@ public interface ContractService{
 	public Contract findById(Long contractId);
 	public String generateAndSavePdfToS3(Long contractId);
 	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, Pageable pageable);
+	public void deleteContract(Long contractId, String email);
 }
 

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -33,8 +33,11 @@ import com.grabpt.dto.request.ContractRequest;
 import com.grabpt.dto.response.ContractResponse;
 import com.grabpt.repository.ContractRepository.ContractRepository;
 import com.grabpt.repository.MatchingRepository.MatchingRepository;
+import com.grabpt.repository.RequestionRepository.RequestionRepository;
 import com.grabpt.service.AlarmService.AlarmService;
 import com.grabpt.service.PdfService.PdfGenerateService;
+
+import jakarta.persistence.EntityManager;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +48,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ContractServiceImpl implements ContractService {
 	private final ContractRepository contractRepository;
 	private final MatchingRepository matchingRepository;
+	private final RequestionRepository requestionRepository;
+	private final EntityManager entityManager;
 	private final AlarmService alarmService;
 	private final PdfGenerateService pdfGenerateService;
 	private final TemplateEngine templateEngine;
@@ -191,6 +196,33 @@ public class ContractServiceImpl implements ContractService {
 			.startDate(contract != null ? contract.getStartDate() : null)
 			.expireDate(contract != null ? contract.getContractDate() : null)
 			.build();
+	}
+
+	@Override
+	@Transactional
+	public void deleteContract(Long contractId, String email) {
+		Contract contract = contractRepository.findById(contractId)
+			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+
+		Matching matching = contract.getMatching();
+		Requestions requestion = matching.getRequestion();
+		Long requestionId = requestion.getId();
+
+		// 요청서 작성자(수강생)만 삭제 가능
+		if (!requestion.getUser().getEmail().equals(email)) {
+			throw new ContractHandler(ErrorStatus.CONTRACT_DELETE_NOT_AUTHORIZED);
+		}
+
+		// 1. Matching 삭제 → Contract, Orders cascade 삭제
+		//    matching.requestion_id, matching.suggestion_id FK 제거됨
+		matchingRepository.delete(matching);
+		entityManager.flush();
+		entityManager.clear(); // 1차 캐시 초기화 (Suggestions.matching이 null로 재조회됨)
+
+		// 2. Requestions 재조회 후 삭제 → 모든 Suggestions, SuggestionPhotos cascade 삭제
+		Requestions freshRequestion = requestionRepository.findById(requestionId)
+			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+		requestionRepository.delete(freshRequestion);
 	}
 
 	@Transactional

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -127,28 +127,31 @@ public class ContractServiceImpl implements ContractService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, Pageable pageable) {
+	public ContractResponse.ContractListResponseDto getContractList(Role role, Long userId, PaymentStatus paymentStatus, String nickname, Pageable pageable) {
+		// 빈 문자열은 null로 처리 (전체 조회)
+		String nicknameFilter = (nickname != null && !nickname.isBlank()) ? nickname.trim() : null;
+
 		Page<Matching> matchings;
 		long totalActive;
 		long totalCompleted;
 
 		if (role == Role.USER) {
 			if (paymentStatus == PaymentStatus.OK) {
-				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			} else if (paymentStatus == PaymentStatus.READY) {
-				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			} else {
-				matchings = matchingRepository.findContractsByUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByUserId(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			}
 			totalActive = matchingRepository.countContractsByUserIdAndNotPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
 			totalCompleted = matchingRepository.countContractsByUserIdAndPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
 		} else {
 			if (paymentStatus == PaymentStatus.OK) {
-				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusOK(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			} else if (paymentStatus == PaymentStatus.READY) {
-				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByProUserIdAndPaymentStatusReady(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			} else {
-				matchings = matchingRepository.findContractsByProUserId(userId, ALL_CONTRACT_STATUSES, pageable);
+				matchings = matchingRepository.findContractsByProUserId(userId, ALL_CONTRACT_STATUSES, nicknameFilter, pageable);
 			}
 			totalActive = matchingRepository.countContractsByProUserIdAndNotPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);
 			totalCompleted = matchingRepository.countContractsByProUserIdAndPaymentStatus(userId, ALL_CONTRACT_STATUSES, PaymentStatus.OK);

--- a/src/main/java/com/grabpt/service/PaymentService/PaymentServiceImpl.java
+++ b/src/main/java/com/grabpt/service/PaymentService/PaymentServiceImpl.java
@@ -2,8 +2,16 @@ package com.grabpt.service.PaymentService;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import com.grabpt.domain.entity.Order;
 import com.grabpt.domain.entity.Users;
@@ -33,46 +41,87 @@ public class PaymentServiceImpl implements PaymentService {
 	private final IamportClient iamportClient;
 	private final AlarmService alarmService;
 
+	@Value("${import.api.key}")
+	private String impApiKey;
+
+	@Value("${import.api.secret}")
+	private String impApiSecret;
+
+	/**
+	 * PortOne V1 결제 단건 조회 (include_sandbox=true 포함)
+	 * 2026-01-26 이후 테스트 채널 결제는 기본적으로 404를 반환하므로 직접 API 호출
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> getPaymentIncludingSandbox(String impUid) {
+		RestTemplate restTemplate = new RestTemplate();
+
+		// 1. 액세스 토큰 발급
+		HttpHeaders tokenHeaders = new HttpHeaders();
+		tokenHeaders.setContentType(MediaType.APPLICATION_JSON);
+		Map<String, String> tokenBody = Map.of("imp_key", impApiKey, "imp_secret", impApiSecret);
+		ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(
+			"https://api.iamport.kr/users/getToken",
+			new HttpEntity<>(tokenBody, tokenHeaders),
+			Map.class
+		);
+		Map<String, Object> tokenData = (Map<String, Object>) tokenResponse.getBody().get("response");
+		String accessToken = (String) tokenData.get("access_token");
+
+		// 2. include_sandbox=true 로 결제 단건 조회
+		HttpHeaders paymentHeaders = new HttpHeaders();
+		paymentHeaders.setBearerAuth(accessToken);
+		ResponseEntity<Map> paymentResponse = restTemplate.exchange(
+			"https://api.iamport.kr/payments/" + impUid + "?include_sandbox=true",
+			HttpMethod.GET,
+			new HttpEntity<>(paymentHeaders),
+			Map.class
+		);
+
+		Map<String, Object> body = paymentResponse.getBody();
+		if (body == null || !Integer.valueOf(0).equals(body.get("code"))) {
+			throw new RuntimeException("결제 조회 실패: " + (body != null ? body.get("message") : "응답 없음"));
+		}
+
+		Map<String, Object> paymentData = (Map<String, Object>) body.get("response");
+		if (paymentData == null) {
+			throw new RuntimeException("존재하지 않는 결제정보입니다.");
+		}
+
+		return paymentData;
+	}
+
 	@Override // 결제 정보 확인 및 검증
 	public IamportResponse<Payment> paymentByCallback(ImPortRequestDto.PaymentCallbackRequest request) {
 		try {
-			// 결제 단건 조회(아임포트)
-			IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse = iamportClient.paymentByImpUid(
-				request.getPayment_uid());
+			Map<String, Object> payment = getPaymentIncludingSandbox(request.getPayment_uid());
 
 			// 주문내역 조회
 			Order order = orderService.findOrderAndPayment(request.getOrder_uid())
 				.orElseThrow(() -> new IllegalArgumentException("주문 내역이 없습니다."));
 
+			String status = (String) payment.get("status");
+			int iamportPrice = ((Number) payment.get("amount")).intValue();
+			String impUid = (String) payment.get("imp_uid");
+
 			// 결제 완료가 아니면
-			if (!iamportResponse.getResponse().getStatus().equals("paid")) {
-				// 주문, 결제 삭제
+			if (!"paid".equals(status)) {
 				orderService.delete(order);
 				paymentRepository.delete(order.getPayment());
-
 				throw new RuntimeException("결제 미완료");
 			}
 
-			// DB에 저장된 결제 금액
-			Long price = order.getPayment().getPrice();
-			// 실 결제 금액
-			int iamportPrice = iamportResponse.getResponse().getAmount().intValue();
-
 			// 결제 금액 검증
+			Long price = order.getPayment().getPrice();
 			if (iamportPrice != price) {
-				// 주문, 결제 삭제
 				orderService.delete(order);
 				paymentRepository.delete(order.getPayment());
-
-				// 결제금액 위변조로 의심되는 결제금액을 취소(아임포트)
 				iamportClient.cancelPaymentByImpUid(
-					new CancelData(iamportResponse.getResponse().getImpUid(), true, new BigDecimal(iamportPrice)));
-
+					new CancelData(impUid, true, new BigDecimal(iamportPrice)));
 				throw new RuntimeException("결제금액 위변조 의심");
 			}
 
 			// 결제 상태 변경
-			order.getPayment().changePaymentBySuccess(PaymentStatus.OK, iamportResponse.getResponse().getImpUid());
+			order.getPayment().changePaymentBySuccess(PaymentStatus.OK, impUid);
 
 			try {
 				Long contractId = order.getMatching().getContract().getId();
@@ -83,7 +132,8 @@ public class PaymentServiceImpl implements PaymentService {
 				log.warn("결제 완료 알람 전송 실패 (결제 상태는 OK로 저장됨): {}", e.getMessage());
 			}
 
-			return iamportResponse;
+			// 라이브러리 응답 객체가 필요한 경우 기존 방식으로 조회 (로깅용)
+			return iamportClient.paymentByImpUid(request.getPayment_uid());
 
 		} catch (IamportResponseException e) {
 			throw new RuntimeException(e);
@@ -148,46 +198,38 @@ public class PaymentServiceImpl implements PaymentService {
 
 	@Override
 	public boolean paymentByCallbackBoolean(ImPortRequestDto.PaymentCallbackRequest request) {
+		log.info("[Payment] paymentCallback 수신 - payment_uid={}, order_uid={}", request.getPayment_uid(),
+			request.getOrder_uid());
 		try {
-			log.info("[Payment] paymentCallback 수신 - payment_uid={}, order_uid={}", request.getPayment_uid(),
-				request.getOrder_uid());
-			// 결제 단건 조회(아임포트)
-			IamportResponse<com.siot.IamportRestClient.response.Payment> iamportResponse = iamportClient.paymentByImpUid(
-				request.getPayment_uid());
+			Map<String, Object> payment = getPaymentIncludingSandbox(request.getPayment_uid());
 
 			// 주문내역 조회
 			Order order = orderService.findOrderAndPayment(request.getOrder_uid())
 				.orElseThrow(() -> new IllegalArgumentException("주문 내역이 없습니다."));
 
+			String status = (String) payment.get("status");
+			int iamportPrice = ((Number) payment.get("amount")).intValue();
+			String impUid = (String) payment.get("imp_uid");
+
 			// 결제 완료가 아니면
-			if (!iamportResponse.getResponse().getStatus().equals("paid")) {
-				// 주문, 결제 삭제
+			if (!"paid".equals(status)) {
 				orderService.delete(order);
 				paymentRepository.delete(order.getPayment());
-
 				throw new RuntimeException("결제 미완료");
 			}
 
-			// DB에 저장된 결제 금액
-			Long price = order.getPayment().getPrice();
-			// 실 결제 금액
-			int iamportPrice = iamportResponse.getResponse().getAmount().intValue();
-
 			// 결제 금액 검증
+			Long price = order.getPayment().getPrice();
 			if (iamportPrice != price) {
-				// 주문, 결제 삭제
 				orderService.delete(order);
 				paymentRepository.delete(order.getPayment());
-
-				// 결제금액 위변조로 의심되는 결제금액을 취소(아임포트)
 				iamportClient.cancelPaymentByImpUid(
-					new CancelData(iamportResponse.getResponse().getImpUid(), true, new BigDecimal(iamportPrice)));
-
+					new CancelData(impUid, true, new BigDecimal(iamportPrice)));
 				throw new RuntimeException("결제금액 위변조 의심");
 			}
 
 			// 결제 상태 변경
-			order.getPayment().changePaymentBySuccess(PaymentStatus.OK, iamportResponse.getResponse().getImpUid());
+			order.getPayment().changePaymentBySuccess(PaymentStatus.OK, impUid);
 
 			try {
 				Long contractId = order.getMatching().getContract().getId();

--- a/src/main/java/com/grabpt/service/PaymentService/PaymentServiceImpl.java
+++ b/src/main/java/com/grabpt/service/PaymentService/PaymentServiceImpl.java
@@ -162,14 +162,17 @@ public class PaymentServiceImpl implements PaymentService {
 		Order order = orderService.findOrderAndPaymentAndMember(orderUid)
 			.orElseThrow(() -> new IllegalArgumentException("주문이 없습니다."));
 
+		String address = (order.getUser().getAddress() != null) ? order.getUser().getAddress().getStreet() : null;
+		String zipcode = (order.getUser().getAddress() != null) ? order.getUser().getAddress().getZipcode() : null;
+
 		return ImPortRequestDto.CustomRequestPayDto.builder()
 			.buyer_name(order.getUser().getUsername())
 			.buyer_email(order.getUser().getEmail())
-			.buyer_address(order.getUser().getAddress().getStreet())
+			.buyer_address(address)
 			.payment_price(order.getPayment().getPrice())
 			.item_name(order.getItemName())
 			.buyer_tel(order.getUser().getPhone_number())
-			.buyer_postcode(order.getUser().getAddress().getZipcode())
+			.buyer_postcode(zipcode)
 			.order_uid(order.getOrderUid())
 			.build();
 	}

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>결제</title>
+    <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
+</head>
+<body>
+<h2>결제 테스트</h2>
+<p>주문번호: <span th:text="${requestDto.order_uid}"></span></p>
+<p>상품명: <span th:text="${requestDto.item_name}"></span></p>
+<p>금액: <span th:text="${requestDto.payment_price}"></span> 원</p>
+<button onclick="requestPay()">결제하기</button>
+<p id="result"></p>
+
+<script th:inline="javascript">
+    IMP.init("imp05656377");
+
+    function requestPay() {
+        const orderUid = /*[[${requestDto.order_uid}]]*/ '';
+        const itemName = /*[[${requestDto.item_name}]]*/ '';
+        const amount = /*[[${requestDto.payment_price}]]*/ 0;
+        const buyerName = /*[[${requestDto.buyer_name}]]*/ '';
+        const buyerEmail = /*[[${requestDto.buyer_email}]]*/ '';
+
+        IMP.request_pay({
+            pg: 'html5_inicis.INIpayTest',
+            pay_method: 'card',
+            merchant_uid: orderUid,
+            name: itemName,
+            amount: amount,
+            buyer_name: buyerName,
+            buyer_email: buyerEmail,
+        }, function(rsp) {
+            if (rsp.success) {
+                document.getElementById('result').innerText = 'imp_uid: ' + rsp.imp_uid;
+                fetch('/paymentCallback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        payment_uid: rsp.imp_uid,
+                        order_uid: rsp.merchant_uid
+                    })
+                }).then(r => r.json()).then(data => {
+                    document.getElementById('result').innerText += '\n결과: ' + JSON.stringify(data);
+                });
+            } else {
+                document.getElementById('result').innerText = '결제 실패: ' + rsp.error_msg;
+            }
+        });
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## PR 제목
- [Feat, Refactor] 결제 로직 수정, 계약서 삭제, 계약서 목록 닉네임 검색

## 변경 사항
 1. 결제 관련 (PaymentService, SecurityConfig)                                                                                                                                                                                     
                                                                                                                                                                                                                                      버그 수정 2건:                                                                                                                                                                                                                    
                                                                                                                                                                                                                                    
  - PortOne 테스트 결제 404 → 결제 상태 READY 고착 문제 해결                                                                                                                                                                        
    - PortOne 2026-01-26 정책 변경으로 테스트 채널 결제가 기존 라이브러리(iamport-rest-client-java)로 조회 시 404 반환
    - 기존 라이브러리 호출 대신 RestTemplate으로 직접 API 호출 + include_sandbox=true 파라미터 적용                                                                                                                                 
    - 알람 전송 실패 시 트랜잭션 롤백되어 결제 상태가 READY로 되돌아가던 문제 → try-catch로 격리                                                                                                                                    
  - POST /paymentCallback 401 오류 수정                                                                                                                                                                                             
    - /payment/** 패턴이 /paymentCallback 경로와 매칭되지 않아 결제 완료 콜백 시 401 반환                                                                                                                                           
    - SecurityConfig permitAll 목록에 /paymentCallback 명시 추가                                                                                                                                                                    
  - findCustomRequestDto NPE 방어                                                                                                                                                                                                   
    - 유저 주소(address)가 null인 경우 NPE 발생 → null 체크 추가                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  2. 계약서 삭제 API (DELETE /contract/{contractId})                                                                                                                                                                                
                                                                                                                                                                                                                                    
  - 신규 API 추가
    - 계약서 삭제 시 연결된 Matching → Contract, Orders(cascade), Requestions → 모든 Suggestions, SuggestionPhotos(cascade) 일괄 삭제                                                                                               
    - JWT 토큰 기반 본인(요청서 작성자/수강생) 확인, 타인 삭제 시 403                                                                                                                                                               
    - entityManager.flush() + clear()로 JPA 1차 캐시 충돌 방지 (Matching 삭제 후 Suggestions cascade 안전 처리)                                                                                                                     
  - 수정 파일: ErrorStatus, ContractService, ContractServiceImpl, ContractController                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  3. 계약서 목록 닉네임 검색 (GET /contract/list?nickname=)                                                                                                                                                                         
                                                                                                                                                                                                                                    
  - 기존 API에 nickname 검색 파라미터 추가 (optional, 없으면 전체 조회)
    - USER 기준: 상대방 트레이너 닉네임으로 부분 검색                                                                                                                                                                               
    - PRO 기준: 상대방 수강생 닉네임으로 부분 검색                                                                                                                                                                                  
    - LIKE CONCAT('%', :nickname, '%') + :nickname IS NULL 패턴으로 단일 쿼리 처리                                                                                                                                                  
    - 상단 요약 카운트(totalActive, totalCompleted)는 검색 필터 미적용 (전체 통계 유지)                                                                                                                                             
  - 수정 파일: MatchingRepository (6개 목록 쿼리), ContractService, ContractServiceImpl, ContractController  

## 작업 내용 체크
- 기능 동작 확인
