### PR TITLE
[Feat] 결제 완료된 계약서 수정/서명/PDF 생성 방지 로직 추가

### DIFF
--- a/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	/// 계약서 관련 오류
 	CONTRACT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CONT4001", "계약이 존재하지 않습니다"),
 	CONTRACT_DELETE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "CONT4031", "계약서 삭제 권한이 없습니다"),
+	CONTRACT_ALREADY_PAID(HttpStatus.BAD_REQUEST, "CONT4002", "이미 결제가 완료된 계약서는 수정할 수 없습니다"),
 
 	/// 이미지 관련 오류
 	NOT_IMAGE(HttpStatus.BAD_REQUEST, "IMG4001", "이미지가 없습니다."),

--- a/src/main/java/com/grabpt/converter/ContractConverter.java
+++ b/src/main/java/com/grabpt/converter/ContractConverter.java
@@ -2,10 +2,20 @@ package com.grabpt.converter;
 
 import com.grabpt.domain.entity.Contract;
 import com.grabpt.domain.entity.ContractInfo;
+import com.grabpt.domain.entity.Order;
+import com.grabpt.domain.entity.Payment;
+import com.grabpt.domain.enums.PaymentStatus;
 import com.grabpt.dto.response.ContractResponse;
 
 public class ContractConverter {
 	public static ContractResponse.ContractResponseDto toContractResponseDto(Contract contract) {
+		PaymentStatus paymentStatus = contract.getMatching().getOrders().stream()
+			.filter(o -> o.getPayment() != null)
+			.map(o -> o.getPayment().getStatus())
+			.filter(s -> s == PaymentStatus.OK)
+			.findFirst()
+			.orElse(PaymentStatus.READY);
+
 		return ContractResponse.ContractResponseDto.builder()
 			.userInfo(contract.getUserInfo() != null ? contract.getUserInfo() : new ContractInfo())
 			.proInfo(contract.getProInfo() != null ? contract.getProInfo() : new ContractInfo())
@@ -16,6 +26,7 @@ public class ContractConverter {
 			.expireDate(contract.getContractDate())
 			.status(contract.getMatching().getStatus())
 			.matchingId(contract.getMatching().getId())
+			.paymentStatus(paymentStatus)
 			.build();
 	}
 }

--- a/src/main/java/com/grabpt/dto/response/ContractResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ContractResponse.java
@@ -48,6 +48,9 @@ public class ContractResponse {
 
 		@Schema(description = "매칭 ID", example = "101")
 		Long matchingId;
+
+		@Schema(description = "결제 상태 (READY: 결제 대기, OK: 결제 완료)", example = "READY")
+		PaymentStatus paymentStatus;
 	}
 
 	@Getter

--- a/src/main/java/com/grabpt/service/ContractService/ContractPhotoServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractPhotoServiceImpl.java
@@ -5,6 +5,7 @@ import com.grabpt.apiPayload.exception.handler.ContractHandler;
 import com.grabpt.aws.s3.AmazonS3Manager;
 import com.grabpt.aws.s3.Uuid;
 import com.grabpt.domain.entity.Contract;
+import com.grabpt.domain.enums.PaymentStatus;
 import com.grabpt.repository.ContractRepository.ContractRepository;
 import com.grabpt.repository.UuidRepository.UuidRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,14 @@ public class ContractPhotoServiceImpl implements ContractPhotoService {
 		if (file == null || file.isEmpty()) {
 			return null;
 		}
+
+		Contract contract = contractRepository.findById(contractId)
+			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+
+		if (isAlreadyPaid(contract)) {
+			throw new ContractHandler(ErrorStatus.CONTRACT_ALREADY_PAID);
+		}
+
 		Uuid uuid = Uuid.builder()
 			.uuid(java.util.UUID.randomUUID().toString())
 			.build();
@@ -43,9 +52,6 @@ public class ContractPhotoServiceImpl implements ContractPhotoService {
 		String keyName = amazonS3Manager.generateContractPhotoKeyName(uuid);
 		String fileUrl = amazonS3Manager.uploadFile(keyName, file);
 
-		Contract contract = contractRepository.findById(contractId)
-			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
-
 		if (isUser) {
 			contract.getUserInfo().setSignImageUrl(fileUrl);
 		} else {
@@ -53,5 +59,12 @@ public class ContractPhotoServiceImpl implements ContractPhotoService {
 		}
 
 		return contract;
+	}
+
+	private boolean isAlreadyPaid(Contract contract) {
+		return contract.getMatching().getOrders().stream()
+			.filter(o -> o.getPayment() != null)
+			.map(o -> o.getPayment().getStatus())
+			.anyMatch(s -> s == PaymentStatus.OK);
 	}
 }

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -64,6 +64,11 @@ public class ContractServiceImpl implements ContractService {
 	public Contract writeUserInfo(Long contractId, ContractRequest.ContractInfoDto request) {
 		Contract contract = contractRepository.findById(contractId)
 			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+
+		if (isAlreadyPaid(contract)) {
+			throw new ContractHandler(ErrorStatus.CONTRACT_ALREADY_PAID);
+		}
+
 		contract.getMatching().setStatus(MatchingStatus.USERWROTE);
 
 		ContractInfo contractInfo = toContractInfo(request);
@@ -80,6 +85,11 @@ public class ContractServiceImpl implements ContractService {
 	public Contract writeProInfo(Long contractId, ContractRequest.ContractInfoForProDto request) {
 		Contract contract = contractRepository.findById(contractId)
 			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+
+		if (isAlreadyPaid(contract)) {
+			throw new ContractHandler(ErrorStatus.CONTRACT_ALREADY_PAID);
+		}
+
 		contract.getMatching().setStatus(MatchingStatus.COMPLETED);
 
 		ContractInfo contractInfo = toContractInfo(request);
@@ -120,6 +130,7 @@ public class ContractServiceImpl implements ContractService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Contract findById(Long contractId) {
 		return contractRepository.findById(contractId)
 			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
@@ -209,10 +220,14 @@ public class ContractServiceImpl implements ContractService {
 
 		Matching matching = contract.getMatching();
 		Requestions requestion = matching.getRequestion();
+		Suggestions suggestion = matching.getSuggestion();
 		Long requestionId = requestion.getId();
 
-		// 요청서 작성자(수강생)만 삭제 가능
-		if (!requestion.getUser().getEmail().equals(email)) {
+		// 요청서 작성자(수강생) 또는 제안서 작성자(전문가)만 삭제 가능
+		boolean isUser = requestion.getUser().getEmail().equals(email);
+		boolean isPro = suggestion.getProProfile().getUser().getEmail().equals(email);
+
+		if (!isUser && !isPro) {
 			throw new ContractHandler(ErrorStatus.CONTRACT_DELETE_NOT_AUTHORIZED);
 		}
 
@@ -231,7 +246,11 @@ public class ContractServiceImpl implements ContractService {
 	@Transactional
 	public String generateAndSavePdfToS3(Long contractId) {
 		Contract contract = contractRepository.findById(contractId)
-			.orElseThrow(() -> new RuntimeException("계약 정보를 찾을 수 없습니다. ID: " + contractId));
+			.orElseThrow(() -> new ContractHandler(ErrorStatus.CONTRACT_NOT_FOUND));
+
+		if (isAlreadyPaid(contract)) {
+			throw new ContractHandler(ErrorStatus.CONTRACT_ALREADY_PAID);
+		}
 
 		Context context = new Context();
 		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
@@ -309,4 +328,10 @@ public class ContractServiceImpl implements ContractService {
 		}
 	}
 
+	private boolean isAlreadyPaid(Contract contract) {
+		return contract.getMatching().getOrders().stream()
+			.filter(o -> o.getPayment() != null)
+			.map(o -> o.getPayment().getStatus())
+			.anyMatch(s -> s == PaymentStatus.OK);
+	}
 }

--- a/src/main/java/com/grabpt/service/PdfService/PdfGenerateService.java
+++ b/src/main/java/com/grabpt/service/PdfService/PdfGenerateService.java
@@ -1,13 +1,10 @@
 package com.grabpt.service.PdfService;
 
-
 import com.microsoft.playwright.*;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -40,35 +37,45 @@ public class PdfGenerateService {
 	@PreDestroy
 	public void cleanup() {
 		executorService.submit(() -> {
-			if(browser != null) {browser.close();}
-			if(playwright != null) {playwright.close();}
+			if (browser != null) {
+				browser.close();
+			}
+			if (playwright != null) {
+				playwright.close();
+			}
 		});
 		executorService.shutdown();
 	}
 
 	public ByteArrayInputStream generatePdfFromHtml(String htmlContent) throws IOException {
-		if(browser == null){
+		if (browser == null) {
 			throw new IOException("PDF 엔진이 아직 준비되지 않았습니다.");
 		}
 
+		long startTime = System.currentTimeMillis();
+
 		try {
 			byte[] pdfBytes = CompletableFuture.supplyAsync(() -> {
-				try(BrowserContext context = browser.newContext()) {
+				try (BrowserContext context = browser.newContext()) {
 					Page page = context.newPage();
 					page.setContent(htmlContent);
 
 					Page.PdfOptions pdfOptions = new Page.PdfOptions()
-						.setFormat("A4")
-						.setPrintBackground(true);
+							.setFormat("A4")
+							.setPrintBackground(true);
 
 					return page.pdf(pdfOptions);
 				}
 			}, executorService).get();
 
+			long elapsed = System.currentTimeMillis() - startTime;
+			log.info("PDF 생성 시간: {} ms", elapsed);
+
 			return new ByteArrayInputStream(pdfBytes);
-		}  catch (Exception e) {
-			log.error("PDF 생성 중 오류 발생",e);
-			throw new IOException("PDF 변환 실패",e);
+
+		} catch (Exception e) {
+			log.error("PDF 생성 중 오류 발생", e);
+			throw new IOException("PDF 변환 실패", e);
 		}
 
 	}


### PR DESCRIPTION
## PR 제목
- [Feat] 결제 완료된 계약서 수정/서명/PDF 생성 방지 로직 추가

## 변경 사항
### 1. 결제 완료 계약서 수정 방지
- `CONTRACT_ALREADY_PAID` 에러 코드 추가 (`CONT4002`)
- 계약서 작성(`writeUserInfo`, `writeProInfo`), 서명 업로드(`uploadSignPhoto`), 
  PDF 생성(`generateAndSavePdfToS3`) 시 결제 완료 여부를 검증하여 수정 차단
- `isAlreadyPaid()` 메서드를 `ContractServiceImpl`, `ContractPhotoServiceImpl`에 추가
### 2. 계약서 응답에 결제 상태 포함
- `ContractResponseDto`에 `paymentStatus` 필드 추가
- `ContractConverter`에서 결제 상태를 조회하여 응답에 반영
### 3. 계약서 삭제 권한 확장
- 기존: 수강생(요청서 작성자)만 삭제 가능
- 변경: 수강생 **또는** 전문가(제안서 작성자)도 삭제 가능
### 4. 기타 개선
- `ContractServiceImpl.findById()`에 `@Transactional(readOnly = true)` 추가
- `generateAndSavePdfToS3()`에서 `RuntimeException` → `ContractHandler` 예외 통일
- `PdfGenerateService` 코드 포맷 정리 및 PDF 생성 소요 시간 로깅 추가

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: None

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
