### PR TITLE
[Fix] 대시보드 PT 횟수 최종 결제 기준 변경 및 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
+++ b/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
@@ -15,9 +15,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class MemberPaymentDto {
 	private Long contractId;
-	private String memberName;       // 회원 이름
-	private Integer ptCount;         // PT 횟수 (Requestions.sessionCount)
-	private Long paymentAmount;      // 결제 금액
-	private Long earnedAmount;       // 적립 금액
+	private String memberName; // 회원 이름
+	private Integer ptCount; // PT 횟수 (Requestions.sessionCount) -> Contract.totalSession 최종 결제 기준의 PT 횟수로 변환
+	private Long paymentAmount; // 결제 금액
+	private Long earnedAmount; // 적립 금액
 	private LocalDateTime paymentDate; // 결제일
+	private String profileImgUrl; // 회원 프로필 이미지
 }

--- a/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
+++ b/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
@@ -15,9 +15,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class UserDashboardDto {
 
-	private Long contractId;         // 계약 id
-	private String userName;       // 회원(트레이너) 이름
-	private Integer ptCount;         // PT 횟수 (Requestions.sessionCount)
-	private Long paymentAmount;      // 결제 금액
+	private Long contractId; // 계약 id
+	private String userName; // 회원(트레이너) 이름
+	private Integer ptCount; // PT 횟수 (Contract.totalSession)
+	private Long paymentAmount; // 결제 금액
+	private String proProfileImgUrl; // 트레이너 프로필 이미지
 	private LocalDateTime paymentDate; // 결제일
 }

--- a/src/main/java/com/grabpt/repository/OrderRepository/OrderRepository.java
+++ b/src/main/java/com/grabpt/repository/OrderRepository/OrderRepository.java
@@ -16,87 +16,88 @@ import com.grabpt.dto.response.UserDashboardDto;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
 	@Query("select o from Order o" +
-		" left join fetch o.payment p" +
-		" left join fetch o.user m" +
-		" where o.orderUid = :orderUid")
+			" left join fetch o.payment p" +
+			" left join fetch o.user m" +
+			" where o.orderUid = :orderUid")
 	Optional<Order> findOrderAndPaymentAndMember(String orderUid);
 
 	@Query("select o from Order o" +
-		" left join fetch o.payment p" +
-		" where o.orderUid = :orderUid")
+			" left join fetch o.payment p" +
+			" where o.orderUid = :orderUid")
 	Optional<Order> findOrderAndPayment(String orderUid);
 
 	/** 트레이너 총 적립 금액 */
 	@Query("SELECT COALESCE(SUM(o.price), 0) FROM Order o " +
-		"JOIN o.matching m " +
-		"JOIN m.suggestion s " +
-		"WHERE s.proProfile.id = :proProfileId " +
-		"AND o.payment.status = :status")
+			"JOIN o.matching m " +
+			"JOIN m.suggestion s " +
+			"WHERE s.proProfile.id = :proProfileId " +
+			"AND o.payment.status = :status")
 	Long getTrainerTotalEarnings(@Param("proProfileId") Long proProfileId,
-		@Param("status") PaymentStatus status);
+			@Param("status") PaymentStatus status);
 
 	/** 트레이너 총 결제 건수 */
 	@Query("SELECT COUNT(o) FROM Order o " +
-		"JOIN o.matching m " +
-		"JOIN m.suggestion s " +
-		"WHERE s.proProfile.id = :proProfileId " +
-		"AND o.payment.status = :status")
+			"JOIN o.matching m " +
+			"JOIN m.suggestion s " +
+			"WHERE s.proProfile.id = :proProfileId " +
+			"AND o.payment.status = :status")
 	Long getTrainerTotalOrders(@Param("proProfileId") Long proProfileId,
-		@Param("status") PaymentStatus status);
+			@Param("status") PaymentStatus status);
 
 	/** 회원 결제 내역 (페이징) */
 	@Query("SELECT new com.grabpt.dto.response.MemberPaymentDto(" +
-		"c.id, " +
-		"u.nickname, " +
-		"r.sessionCount, " +
-		"o.price, " +
-		"o.price, " +
-		"p.createdAt) " +
-		"FROM Order o " +
-		"JOIN o.payment p " +
-		"JOIN o.matching m " +
-		"JOIN m.suggestion s " +
-		"JOIN m.requestion r " +
-		"JOIN m.contract c " +
-		"JOIN r.user u " +
-		"WHERE s.proProfile.id = :proProfileId " +
-		"AND p.status = :status " +
-		"ORDER BY p.createdAt DESC")
+			"c.id, " +
+			"u.nickname, " +
+			"c.totalSession, " +
+			"o.price, " +
+			"o.price, " +
+			"p.createdAt, " +
+			"u.profileImageUrl) " +
+			"FROM Order o " +
+			"JOIN o.payment p " +
+			"JOIN o.matching m " +
+			"JOIN m.suggestion s " +
+			"JOIN m.requestion r " +
+			"JOIN m.contract c " +
+			"JOIN r.user u " +
+			"WHERE s.proProfile.id = :proProfileId " +
+			"AND p.status = :status " +
+			"ORDER BY p.createdAt DESC")
 	Page<MemberPaymentDto> getMemberPayments(@Param("proProfileId") Long proProfileId,
-		@Param("status") PaymentStatus status,
-		Pageable pageable);
+			@Param("status") PaymentStatus status,
+			Pageable pageable);
 
 	/** 회원: 총 결제 금액 */
 	@Query("""
-		    SELECT COALESCE(SUM(o.price), 0)
-		    FROM Order o
-		    WHERE o.user.id = :userId
-		      AND o.payment.status = :status
-		""")
+			    SELECT COALESCE(SUM(o.price), 0)
+			    FROM Order o
+			    WHERE o.user.id = :userId
+			      AND o.payment.status = :status
+			""")
 	Long getUserTotalSpent(@Param("userId") Long userId,
-		@Param("status") PaymentStatus status);
+			@Param("status") PaymentStatus status);
 
 	/** 회원: 총 결제 건수 */
 	@Query("""
-		    SELECT COUNT(o)
-		    FROM Order o
-		    WHERE o.user.id = :userId
-		      AND o.payment.status = :status
-		""")
+			    SELECT COUNT(o)
+			    FROM Order o
+			    WHERE o.user.id = :userId
+			      AND o.payment.status = :status
+			""")
 	Long getUserTotalOrders(@Param("userId") Long userId,
-		@Param("status") PaymentStatus status);
+			@Param("status") PaymentStatus status);
 
 	/**
 	 * 회원: 결제 내역 (페이징) → UserDashboardDto
 	 * - countQuery를 명시해서 페이징/카운트 불일치 문제 방지
 	 */
-	@Query(
-		value = """
+	@Query(value = """
 			    SELECT new com.grabpt.dto.response.UserDashboardDto(
 			        c.id,
 			        trainerUser.nickname,
-			        r.sessionCount,
+			        c.totalSession,
 			        o.price,
+					trainerUser.profileImageUrl,
 			        p.createdAt
 			    )
 			    FROM Order o
@@ -110,17 +111,15 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 			    WHERE o.user.id = :userId
 			      AND p.status = :status
 			    ORDER BY p.createdAt DESC
-			""",
-		countQuery = """
+			""", countQuery = """
 			    SELECT COUNT(o)
 			    FROM Order o
 			      JOIN o.payment p
 			      JOIN o.matching m
 			    WHERE o.user.id = :userId
 			      AND p.status = :status
-			"""
-	)
+			""")
 	Page<UserDashboardDto> getUserPayments(@Param("userId") Long userId,
-		@Param("status") PaymentStatus status,
-		Pageable pageable);
+			@Param("status") PaymentStatus status,
+			Pageable pageable);
 }


### PR DESCRIPTION
## PR 제목
- [Fix] 대시보드 PT 횟수 최종 결제 기준 변경 및 프로필 이미지 추가


## 변경 사항
- 회원/트레이너 대시보드 API(/api/user/dashboard, /api/trainer/dashboard)의 PT 횟수가 요청서(Requestions.sessionCount) 기준이 아닌 최종 결제 기준(Contract.totalSession) 으로 조회되도록 수정
- 회원 결제 대시보드에 결제한 전문가 프로필 이미지(proProfileImgUrl) 추가
- 전문가 대시보드에 결제한 회원 프로필 이미지(profileImgUrl) 추가

## 작업 내용 체크
- 기능 동작 확인
- 테스트 코드 작성
- 코드 리뷰 반영
- ...

## 관련 이슈
- 대시보드 PT 횟수 데이터 불일치 이슈

## 기타 공유 사항
- createContract에서 초기값 LocalDate.now()로 설정 후, 전문가 계약서 작성 시(writeProInfo) request.getExpireDate()로 정상 업데이트됩니다. 
프론트에서 expireDate 값이 제대로 전송되는지 확인 필요