### PR TITLE
[Fix] 대시보드 imageURL 타입 string 고정 및 PDF 유효기간 버그 수정

### DIFF
--- a/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
+++ b/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
@@ -2,6 +2,7 @@ package com.grabpt.dto.response;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,5 +21,6 @@ public class MemberPaymentDto {
 	private Long paymentAmount; // 결제 금액
 	private Long earnedAmount; // 적립 금액
 	private LocalDateTime paymentDate; // 결제일
+	@Schema(type = "string", description = "회원 프로필 이미지 URL")
 	private String profileImgUrl; // 회원 프로필 이미지
 }

--- a/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
+++ b/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
@@ -2,6 +2,7 @@ package com.grabpt.dto.response;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class UserDashboardDto {
 	private String userName; // 회원(트레이너) 이름
 	private Integer ptCount; // PT 횟수 (Contract.totalSession)
 	private Long paymentAmount; // 결제 금액
+	@Schema(type = "string", description = "트레이너 프로필 이미지 URL")
 	private String proProfileImgUrl; // 트레이너 프로필 이미지
 	private LocalDateTime paymentDate; // 결제일
 }

--- a/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ContractService/ContractServiceImpl.java
@@ -284,10 +284,10 @@ public class ContractServiceImpl implements ContractService {
 		Integer pricePerSession = contract.getPrice() != null ? contract.getPrice() : 0;
 		long totalPrice = (long)totalSession * pricePerSession;
 
-		// 유효기간 (예: 시작일로부터 3개월) - 정책에 맞게 수정 필요
+		// 유효기간: 트레이너가 입력한 expireDate (contractDate 필드)를 사용
 		String endDateStr = "-";
-		if (contract.getStartDate() != null) {
-			endDateStr = contract.getStartDate().plusMonths(3).format(dateFormatter);
+		if (contract.getContractDate() != null) {
+			endDateStr = contract.getContractDate().format(dateFormatter);
 		}
 
 		Map<String, Object> service = Map.of(


### PR DESCRIPTION
## PR 제목
- [Fix] 대시보드 imageURL 타입 string 고정 및 PDF 유효기간 버그 수정

## 변경 사항
- MemberPaymentDto, UserDashboardDto의 이미지 URL 필드에 @Schema(type="string") 추가
- PDF 생성 시 유효기간이 startDate+3개월로 하드코딩된 버그 수정 → 트레이너 입력값(expireDate) 사용

## 작업 내용 체크
- 기능 동작 확인
- 테스트 코드 작성
- 코드 리뷰 반영
- ...

## 관련 이슈
- 관련 이슈 번호: #467 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
