### PR TITLE
[Refactor] 대시보드 관련 DTO 프로필 이미지 필드명 imageURL로 통일

### DIFF
--- a/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
+++ b/src/main/java/com/grabpt/dto/response/MemberPaymentDto.java
@@ -2,7 +2,6 @@ package com.grabpt.dto.response;
 
 import java.time.LocalDateTime;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +20,5 @@ public class MemberPaymentDto {
 	private Long paymentAmount; // 결제 금액
 	private Long earnedAmount; // 적립 금액
 	private LocalDateTime paymentDate; // 결제일
-	@Schema(type = "string", description = "회원 프로필 이미지 URL")
-	private String profileImgUrl; // 회원 프로필 이미지
+	private String imageURL; // 회원 프로필 이미지
 }

--- a/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
+++ b/src/main/java/com/grabpt/dto/response/UserDashboardDto.java
@@ -2,7 +2,6 @@ package com.grabpt.dto.response;
 
 import java.time.LocalDateTime;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +19,6 @@ public class UserDashboardDto {
 	private String userName; // 회원(트레이너) 이름
 	private Integer ptCount; // PT 횟수 (Contract.totalSession)
 	private Long paymentAmount; // 결제 금액
-	@Schema(type = "string", description = "트레이너 프로필 이미지 URL")
-	private String proProfileImgUrl; // 트레이너 프로필 이미지
+	private String imageURL; // 트레이너 프로필 이미지
 	private LocalDateTime paymentDate; // 결제일
 }


### PR DESCRIPTION
## PR 제목
- [Feat] 회원가입 API 구현
- [Fix] 로그인 예외 처리 수정

## 변경 사항
- MemberPaymentDto, UserDashboardDto의 프로필 이미지 필드명을 imageURL로 일원화
- 불필요한 io.swagger.v3.oas.annotations.media.Schema 어노테이션 제거

## 작업 내용 체크
- 기능 동작 확인
- 테스트 코드 작성
- 코드 리뷰 반영
- ...

## 관련 이슈
- 관련 이슈 번호: #468 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
