### PR TITLE
[Feat] 환불 기능 구현

### DIFF
--- a/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/grabpt/apiPayload/code/status/ErrorStatus.java
@@ -73,6 +73,15 @@ public enum ErrorStatus implements BaseErrorCode {
 	SUGGESTION_DELETE_NOT_ALLOWED_STATUS(HttpStatus.BAD_REQUEST, "SUGG4006", "매칭 진행/완료된 제안서는 삭제할 수 없습니다."),
 	SUGGESTION_DELETE_NOT_OWNER(HttpStatus.FORBIDDEN, "SUGG4007", "제안서 작성자만 삭제할 수 있습니다."),
 
+	/// 환불 관련 오류
+	REFUND_NOT_FOUND(HttpStatus.BAD_REQUEST, "REFUND4001", "환불 내역이 존재하지 않습니다."),
+	REFUND_ALREADY_REQUESTED(HttpStatus.BAD_REQUEST, "REFUND4002", "이미 환불 신청이 완료된 주문입니다."),
+	REFUND_NOT_PAID(HttpStatus.BAD_REQUEST, "REFUND4003", "결제 완료된 주문만 환불 신청이 가능합니다."),
+	REFUND_NOT_PENDING(HttpStatus.BAD_REQUEST, "REFUND4004", "환불 대기 상태의 신청만 처리할 수 있습니다."),
+	REFUND_UNAUTHORIZED(HttpStatus.FORBIDDEN, "REFUND4031", "해당 환불을 처리할 권한이 없습니다."),
+	REFUND_ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "REFUND4005", "환불 대상 주문을 찾을 수 없습니다."),
+	REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "REFUND5001", "PortOne 환불 처리 중 오류가 발생했습니다."),
+
 	/// 인증 관련 오류
 	INVALID_JWT_ISSUE(HttpStatus.BAD_REQUEST, "JWT4001", "유효한 JWT 토큰이 아닙니다."),
 	INVALID_JWT_ISSUE_REFRESH(HttpStatus.BAD_REQUEST, "JWT4002", "유효한 Refresh 토큰이 아닙니다."),

--- a/src/main/java/com/grabpt/apiPayload/exception/handler/RefundHandler.java
+++ b/src/main/java/com/grabpt/apiPayload/exception/handler/RefundHandler.java
@@ -1,0 +1,10 @@
+package com.grabpt.apiPayload.exception.handler;
+
+import com.grabpt.apiPayload.code.BaseErrorCode;
+import com.grabpt.apiPayload.exception.GeneralException;
+
+public class RefundHandler extends GeneralException {
+    public RefundHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/grabpt/controller/RefundController.java
+++ b/src/main/java/com/grabpt/controller/RefundController.java
@@ -1,0 +1,89 @@
+package com.grabpt.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grabpt.apiPayload.ApiResponse;
+import com.grabpt.config.SecurityUtils;
+import com.grabpt.dto.request.RefundRequest;
+import com.grabpt.dto.response.RefundResponse;
+import com.grabpt.service.RefundService.RefundService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/refund")
+public class RefundController {
+
+    private final RefundService refundService;
+
+    @Operation(
+        summary = "환불 신청 API (USER)",
+        description = "결제 완료된 주문에 대해 환불을 신청합니다. " +
+            "계약 시작일 전이면 자동 전액 환불, 시작일 이후이면 PRO 확인 후 처리됩니다."
+    )
+    @PostMapping("/request")
+    public ApiResponse<RefundResponse.RefundResponseDto> requestRefund(
+        @RequestBody RefundRequest.RefundRequestDto request) {
+        Long userId = SecurityUtils.currentUserIdOrThrow();
+        return ApiResponse.onSuccess(refundService.requestRefund(userId, request));
+    }
+
+    @Operation(
+        summary = "환불 승인 API (PRO)",
+        description = "PENDING 상태의 환불 신청을 승인합니다. PortOne 환불 API를 호출하여 실제 환불을 처리합니다."
+    )
+    @PatchMapping("/{refundId}/approve")
+    public ApiResponse<RefundResponse.RefundResponseDto> approveRefund(
+        @PathVariable Long refundId) {
+        Long proUserId = SecurityUtils.currentUserIdOrThrow();
+        return ApiResponse.onSuccess(refundService.approveRefund(proUserId, refundId));
+    }
+
+    @Operation(
+        summary = "환불 거절 API (PRO)",
+        description = "PENDING 상태의 환불 신청을 거절합니다."
+    )
+    @PatchMapping("/{refundId}/reject")
+    public ApiResponse<RefundResponse.RefundResponseDto> rejectRefund(
+        @PathVariable Long refundId,
+        @RequestBody RefundRequest.RefundRejectDto request) {
+        Long proUserId = SecurityUtils.currentUserIdOrThrow();
+        return ApiResponse.onSuccess(refundService.rejectRefund(proUserId, refundId, request));
+    }
+
+    @Operation(
+        summary = "환불 정보 조회 API (USER/PRO)",
+        description = "특정 환불 신청의 상세 정보를 조회합니다. 해당 계약의 USER 또는 PRO만 조회 가능합니다."
+    )
+    @GetMapping("/{refundId}")
+    public ApiResponse<RefundResponse.RefundResponseDto> getRefund(
+        @PathVariable Long refundId) {
+        Long userId = SecurityUtils.currentUserIdOrThrow();
+        return ApiResponse.onSuccess(refundService.getRefund(userId, refundId));
+    }
+
+    @Operation(
+        summary = "내 환불 내역 조회 API (USER)",
+        description = "로그인한 USER의 환불 신청 내역을 페이지네이션으로 조회합니다."
+    )
+    @GetMapping("/my")
+    public ApiResponse<Page<RefundResponse.RefundResponseDto>> getMyRefunds(
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size) {
+        Long userId = SecurityUtils.currentUserIdOrThrow();
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+        return ApiResponse.onSuccess(refundService.getMyRefunds(userId, pageable));
+    }
+}

--- a/src/main/java/com/grabpt/converter/RefundConverter.java
+++ b/src/main/java/com/grabpt/converter/RefundConverter.java
@@ -1,0 +1,21 @@
+package com.grabpt.converter;
+
+import com.grabpt.domain.entity.Refund;
+import com.grabpt.dto.response.RefundResponse;
+
+public class RefundConverter {
+
+    public static RefundResponse.RefundResponseDto toRefundResponseDto(Refund refund) {
+        return RefundResponse.RefundResponseDto.builder()
+            .refundId(refund.getId())
+            .orderId(refund.getOrder().getId())
+            .userId(refund.getUser().getId())
+            .status(refund.getStatus())
+            .reason(refund.getReason())
+            .refundAmount(refund.getRefundAmount())
+            .refundUid(refund.getRefundUid())
+            .rejectionReason(refund.getRejectionReason())
+            .createdAt(refund.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/grabpt/domain/entity/Payment.java
+++ b/src/main/java/com/grabpt/domain/entity/Payment.java
@@ -39,4 +39,8 @@ public class Payment extends BaseEntity {
 		this.status = status;
 		this.paymentUid = paymentUid;
 	}
+
+	public void changePaymentByCancel() {
+		this.status = PaymentStatus.CANCEL;
+	}
 }

--- a/src/main/java/com/grabpt/domain/entity/Refund.java
+++ b/src/main/java/com/grabpt/domain/entity/Refund.java
@@ -1,0 +1,69 @@
+package com.grabpt.domain.entity;
+
+import com.grabpt.domain.common.BaseEntity;
+import com.grabpt.domain.enums.RefundStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Refund extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    private RefundStatus status;
+
+    private String reason;           // 환불 신청 사유
+    private Long refundAmount;       // 환불 금액
+    private String refundUid;        // PortOne 환불 트랜잭션 ID
+    private String rejectionReason;  // 거절 사유
+
+    @Builder
+    public Refund(Order order, Users user, RefundStatus status, String reason, Long refundAmount) {
+        this.order = order;
+        this.user = user;
+        this.status = status;
+        this.reason = reason;
+        this.refundAmount = refundAmount;
+    }
+
+    public void approve(String refundUid) {
+        this.status = RefundStatus.APPROVED;
+        this.refundUid = refundUid;
+    }
+
+    public void autoApprove(String refundUid) {
+        this.status = RefundStatus.AUTO_APPROVED;
+        this.refundUid = refundUid;
+    }
+
+    public void reject(String rejectionReason) {
+        this.status = RefundStatus.REJECTED;
+        this.rejectionReason = rejectionReason;
+    }
+}

--- a/src/main/java/com/grabpt/domain/enums/RefundStatus.java
+++ b/src/main/java/com/grabpt/domain/enums/RefundStatus.java
@@ -1,0 +1,8 @@
+package com.grabpt.domain.enums;
+
+public enum RefundStatus {
+    PENDING,        // 환불 신청됨 (PRO 확인 대기)
+    APPROVED,       // PRO가 승인 (PortOne 환불 처리 완료)
+    REJECTED,       // PRO가 거절
+    AUTO_APPROVED   // 시작일 전 자동 전액 환불
+}

--- a/src/main/java/com/grabpt/dto/request/RefundRequest.java
+++ b/src/main/java/com/grabpt/dto/request/RefundRequest.java
@@ -1,0 +1,20 @@
+package com.grabpt.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RefundRequest {
+
+    @Getter
+    @NoArgsConstructor
+    public static class RefundRequestDto {
+        private Long orderId;
+        private String reason;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class RefundRejectDto {
+        private String rejectionReason;
+    }
+}

--- a/src/main/java/com/grabpt/dto/response/RefundResponse.java
+++ b/src/main/java/com/grabpt/dto/response/RefundResponse.java
@@ -1,0 +1,32 @@
+package com.grabpt.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.grabpt.domain.enums.RefundStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+public class RefundResponse {
+
+    @Getter
+    @Builder
+    public static class RefundResponseDto {
+        private Long refundId;
+        private Long orderId;
+        private Long userId;
+        private RefundStatus status;
+        private String reason;
+        private Long refundAmount;
+        private String refundUid;
+        private String rejectionReason;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class RefundListResponseDto {
+        private Page<RefundResponseDto> refunds;
+    }
+}

--- a/src/main/java/com/grabpt/repository/RefundRepository/RefundRepository.java
+++ b/src/main/java/com/grabpt/repository/RefundRepository/RefundRepository.java
@@ -1,0 +1,22 @@
+package com.grabpt.repository.RefundRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.grabpt.domain.entity.Refund;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+    boolean existsByOrderId(Long orderId);
+
+    Optional<Refund> findByOrderId(Long orderId);
+
+    @Query("SELECT r FROM Refund r WHERE r.user.id = :userId ORDER BY r.id DESC")
+    Page<Refund> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
+}

--- a/src/main/java/com/grabpt/service/RefundService/RefundService.java
+++ b/src/main/java/com/grabpt/service/RefundService/RefundService.java
@@ -1,0 +1,20 @@
+package com.grabpt.service.RefundService;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.grabpt.dto.request.RefundRequest;
+import com.grabpt.dto.response.RefundResponse;
+
+public interface RefundService {
+
+    RefundResponse.RefundResponseDto requestRefund(Long userId, RefundRequest.RefundRequestDto request);
+
+    RefundResponse.RefundResponseDto approveRefund(Long proUserId, Long refundId);
+
+    RefundResponse.RefundResponseDto rejectRefund(Long proUserId, Long refundId, RefundRequest.RefundRejectDto request);
+
+    RefundResponse.RefundResponseDto getRefund(Long userId, Long refundId);
+
+    Page<RefundResponse.RefundResponseDto> getMyRefunds(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/grabpt/service/RefundService/RefundServiceImpl.java
+++ b/src/main/java/com/grabpt/service/RefundService/RefundServiceImpl.java
@@ -1,0 +1,208 @@
+package com.grabpt.service.RefundService;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grabpt.apiPayload.code.status.ErrorStatus;
+import com.grabpt.apiPayload.exception.handler.RefundHandler;
+import com.grabpt.converter.RefundConverter;
+import com.grabpt.domain.entity.Contract;
+import com.grabpt.domain.entity.Order;
+import com.grabpt.domain.entity.Refund;
+import com.grabpt.domain.entity.Users;
+import com.grabpt.domain.enums.PaymentStatus;
+import com.grabpt.domain.enums.RefundStatus;
+import com.grabpt.dto.request.RefundRequest;
+import com.grabpt.dto.response.RefundResponse;
+import com.grabpt.repository.OrderRepository.OrderRepository;
+import com.grabpt.repository.RefundRepository.RefundRepository;
+import com.grabpt.repository.UserRepository.UserRepository;
+import com.grabpt.service.AlarmService.AlarmService;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class RefundServiceImpl implements RefundService {
+
+    private final RefundRepository refundRepository;
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final AlarmService alarmService;
+    private final IamportClient iamportClient;
+
+    @Value("${import.api.key}")
+    private String impApiKey;
+
+    @Value("${import.api.secret}")
+    private String impApiSecret;
+
+    @Override
+    public RefundResponse.RefundResponseDto requestRefund(Long userId, RefundRequest.RefundRequestDto request) {
+        Order order = orderRepository.findById(request.getOrderId())
+            .orElseThrow(() -> new RefundHandler(ErrorStatus.REFUND_ORDER_NOT_FOUND));
+
+        // 결제 완료 상태 확인
+        if (order.getPayment() == null || order.getPayment().getStatus() != PaymentStatus.OK) {
+            throw new RefundHandler(ErrorStatus.REFUND_NOT_PAID);
+        }
+
+        // 중복 환불 신청 방지
+        if (refundRepository.existsByOrderId(order.getId())) {
+            throw new RefundHandler(ErrorStatus.REFUND_ALREADY_REQUESTED);
+        }
+
+        Users user = userRepository.findById(userId)
+            .orElseThrow(() -> new RefundHandler(ErrorStatus.REFUND_UNAUTHORIZED));
+
+        Contract contract = order.getMatching().getContract();
+        Long proUserId = order.getMatching().getSuggestion().getProProfile().getUser().getId();
+        Long refundAmount = order.getPayment().getPrice();
+        LocalDate startDate = contract.getStartDate();
+
+        Refund refund = Refund.builder()
+            .order(order)
+            .user(user)
+            .reason(request.getReason())
+            .refundAmount(refundAmount)
+            .status(RefundStatus.PENDING)
+            .build();
+
+        // 시작일 전이면 자동 전액 환불
+        if (startDate == null || !LocalDate.now().isAfter(startDate.minusDays(1))) {
+            String refundUid = cancelPortOnePayment(order.getPayment().getPaymentUid(), refundAmount, request.getReason());
+            order.getPayment().changePaymentByCancel();
+            refund.autoApprove(refundUid);
+            refundRepository.save(refund);
+
+            alarmService.sendAlarm(userId, "REFUND", "환불 완료",
+                "환불이 자동으로 완료되었습니다.", "/refund/" + refund.getId());
+            alarmService.sendAlarm(proUserId, "REFUND", "환불 처리 완료",
+                "계약 시작 전 환불 신청으로 자동 처리되었습니다.", "/refund/" + refund.getId());
+        } else {
+            // 시작일 이후이면 PRO 확인 대기
+            refundRepository.save(refund);
+
+            alarmService.sendAlarm(proUserId, "REFUND", "환불 신청 접수",
+                "수강생이 환불을 신청했습니다. 확인 후 처리해주세요.", "/refund/" + refund.getId());
+            alarmService.sendAlarm(userId, "REFUND", "환불 신청 완료",
+                "환불 신청이 완료되었습니다. 트레이너 확인 후 처리됩니다.", "/refund/" + refund.getId());
+        }
+
+        return RefundConverter.toRefundResponseDto(refund);
+    }
+
+    @Override
+    public RefundResponse.RefundResponseDto approveRefund(Long proUserId, Long refundId) {
+        Refund refund = refundRepository.findById(refundId)
+            .orElseThrow(() -> new RefundHandler(ErrorStatus.REFUND_NOT_FOUND));
+
+        validateProAuthority(proUserId, refund);
+
+        if (refund.getStatus() != RefundStatus.PENDING) {
+            throw new RefundHandler(ErrorStatus.REFUND_NOT_PENDING);
+        }
+
+        Order order = refund.getOrder();
+        String refundUid = cancelPortOnePayment(
+            order.getPayment().getPaymentUid(),
+            refund.getRefundAmount(),
+            refund.getReason()
+        );
+
+        order.getPayment().changePaymentByCancel();
+        refund.approve(refundUid);
+
+        Long userId = refund.getUser().getId();
+        alarmService.sendAlarm(userId, "REFUND", "환불 승인",
+            "환불 신청이 승인되어 처리되었습니다.", "/refund/" + refundId);
+        alarmService.sendAlarm(proUserId, "REFUND", "환불 승인 완료",
+            "환불 승인이 완료되었습니다.", "/refund/" + refundId);
+
+        return RefundConverter.toRefundResponseDto(refund);
+    }
+
+    @Override
+    public RefundResponse.RefundResponseDto rejectRefund(Long proUserId, Long refundId, RefundRequest.RefundRejectDto request) {
+        Refund refund = refundRepository.findById(refundId)
+            .orElseThrow(() -> new RefundHandler(ErrorStatus.REFUND_NOT_FOUND));
+
+        validateProAuthority(proUserId, refund);
+
+        if (refund.getStatus() != RefundStatus.PENDING) {
+            throw new RefundHandler(ErrorStatus.REFUND_NOT_PENDING);
+        }
+
+        refund.reject(request.getRejectionReason());
+
+        Long userId = refund.getUser().getId();
+        alarmService.sendAlarm(userId, "REFUND", "환불 거절",
+            "환불 신청이 거절되었습니다. 사유: " + request.getRejectionReason(), "/refund/" + refundId);
+
+        return RefundConverter.toRefundResponseDto(refund);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RefundResponse.RefundResponseDto getRefund(Long userId, Long refundId) {
+        Refund refund = refundRepository.findById(refundId)
+            .orElseThrow(() -> new RefundHandler(ErrorStatus.REFUND_NOT_FOUND));
+
+        Long refundUserId = refund.getUser().getId();
+        Long proUserId = refund.getOrder().getMatching().getSuggestion().getProProfile().getUser().getId();
+
+        if (!userId.equals(refundUserId) && !userId.equals(proUserId)) {
+            throw new RefundHandler(ErrorStatus.REFUND_UNAUTHORIZED);
+        }
+
+        return RefundConverter.toRefundResponseDto(refund);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<RefundResponse.RefundResponseDto> getMyRefunds(Long userId, Pageable pageable) {
+        return refundRepository.findAllByUserId(userId, pageable)
+            .map(RefundConverter::toRefundResponseDto);
+    }
+
+    private void validateProAuthority(Long proUserId, Refund refund) {
+        Long contractProUserId = refund.getOrder().getMatching().getSuggestion().getProProfile().getUser().getId();
+        if (!proUserId.equals(contractProUserId)) {
+            throw new RefundHandler(ErrorStatus.REFUND_UNAUTHORIZED);
+        }
+    }
+
+    private String cancelPortOnePayment(String paymentUid, Long amount, String reason) {
+        try {
+            CancelData cancelData = new CancelData(paymentUid, true, new BigDecimal(amount));
+            cancelData.setReason(reason != null ? reason : "환불 신청");
+
+            com.siot.IamportRestClient.response.IamportResponse<com.siot.IamportRestClient.response.Payment> response =
+                iamportClient.cancelPaymentByImpUid(cancelData);
+
+            if (response.getCode() != 0) {
+                log.error("PortOne 환불 실패: {}", response.getMessage());
+                throw new RefundHandler(ErrorStatus.REFUND_FAILED);
+            }
+
+            return response.getResponse().getImpUid();
+
+        } catch (IamportResponseException | IOException e) {
+            log.error("PortOne 환불 처리 중 오류 발생: {}", e.getMessage());
+            throw new RefundHandler(ErrorStatus.REFUND_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## PR 제목
- [Feat] 환불 기능 구현

## 변경 사항
- 결제 완료된 주문에 대한 환불 신청/승인/거절 API 구현
- 계약 시작일 기준 자동 환불 / PRO 승인 분기 처리
- PortOne 환불 API 연동

## 작업 내용 체크
- 로컬 기능 동작 확인
<img width="334" height="370" alt="image" src="https://github.com/user-attachments/assets/6d294f16-1d9e-4b25-95a7-7ee642835572" />


## 관련 이슈
- 관련 이슈 번호: #470

## 기타 공유 사항
- 계약 시작일(`startDate`) 기준으로 환불 분기 처리됨
  - 시작일 이전: 자동 즉시 환불 (status: APPROVED)
  - 시작일 이후: PRO 승인 대기 (status: PENDING)
- `startDate`는 PRO가 계약서 작성 시 입력하는 값
- PortOne 테스트 환경에서 환불 정상 동작 확인
