### PR TITLE
[Feat] 트레이너 찾기 검색 API 구현

### DIFF
--- a/src/main/java/com/grabpt/config/SecurityConfig.java
+++ b/src/main/java/com/grabpt/config/SecurityConfig.java
@@ -122,6 +122,7 @@ public class SecurityConfig {
 					"/paymentCallback",
 					"/api/sms/**",
 					"/api/category-proprofile/**",
+					"/api/pro/search",
 					"/api/*/reviews",
 					"/api/allAlarmList",
 					"/api/unreadAlarmList",

--- a/src/main/java/com/grabpt/controller/ProProfileController.java
+++ b/src/main/java/com/grabpt/controller/ProProfileController.java
@@ -1,5 +1,8 @@
 package com.grabpt.controller;
 
+import com.grabpt.domain.enums.SortType;
+import com.grabpt.dto.request.ProSearchRequest;
+import com.grabpt.dto.response.ProSearchResponse;
 import com.grabpt.service.ProfileService.ProfileFacade;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -49,6 +52,38 @@ public class ProProfileController {
 		@PathVariable(name = "userCode") Long userId) {
 		ProProfileResponseDTO proProfile = profileFacade.findProProfileByUser(userId);
 		return ApiResponse.onSuccess(proProfile);
+	}
+
+	@Operation(
+		summary = "트레이너 검색 API",
+		description = "키워드, 카테고리, 지역, 가격, 평점 조건으로 트레이너를 검색합니다. " +
+			"sortBy: RATING(기본) / PRICE_ASC / PRICE_DESC / REVIEW_COUNT"
+	)
+	@GetMapping("/pro/search")
+	public ApiResponse<Page<ProSearchResponse>> searchProfiles(
+		@RequestParam(required = false) String keyword,
+		@RequestParam(required = false) String categoryCode,
+		@RequestParam(required = false) String city,
+		@RequestParam(required = false) String district,
+		@RequestParam(required = false) Integer minPrice,
+		@RequestParam(required = false) Integer maxPrice,
+		@RequestParam(required = false) Double minRating,
+		@RequestParam(required = false, defaultValue = "RATING") SortType sortBy,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "20") int size) {
+
+		ProSearchRequest request = new ProSearchRequest();
+		request.setKeyword(keyword);
+		request.setCategoryCode(categoryCode);
+		request.setCity(city);
+		request.setDistrict(district);
+		request.setMinPrice(minPrice);
+		request.setMaxPrice(maxPrice);
+		request.setMinRating(minRating);
+		request.setSortBy(sortBy);
+
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+		return ApiResponse.onSuccess(profileFacade.searchProfiles(request, pageable));
 	}
 
 }

--- a/src/main/java/com/grabpt/domain/enums/SortType.java
+++ b/src/main/java/com/grabpt/domain/enums/SortType.java
@@ -1,0 +1,5 @@
+package com.grabpt.domain.enums;
+
+public enum SortType {
+    RATING, PRICE_ASC, PRICE_DESC, REVIEW_COUNT
+}

--- a/src/main/java/com/grabpt/dto/request/ProSearchRequest.java
+++ b/src/main/java/com/grabpt/dto/request/ProSearchRequest.java
@@ -1,0 +1,18 @@
+package com.grabpt.dto.request;
+
+import com.grabpt.domain.enums.SortType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProSearchRequest {
+    private String keyword;
+    private String categoryCode;
+    private String city;
+    private String district;
+    private Integer minPrice;
+    private Integer maxPrice;
+    private Double minRating;
+    private SortType sortBy = SortType.RATING;
+}

--- a/src/main/java/com/grabpt/dto/response/ProSearchResponse.java
+++ b/src/main/java/com/grabpt/dto/response/ProSearchResponse.java
@@ -1,0 +1,54 @@
+package com.grabpt.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProSearchResponse {
+
+    @Schema(description = "프로 프로필 ID", example = "1")
+    private Long proProfileId;
+
+    @Schema(description = "유저 ID", example = "10")
+    private Long userId;
+
+    @Schema(description = "닉네임", example = "강프로")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "센터명", example = "강남 PT센터")
+    private String center;
+
+    @Schema(description = "카테고리 코드", example = "PT")
+    private String categoryCode;
+
+    @Schema(description = "카테고리명", example = "퍼스널 트레이닝")
+    private String categoryName;
+
+    @Schema(description = "경력(연차)", example = "5")
+    private Integer career;
+
+    @Schema(description = "1회 가격(원)", example = "50000")
+    private Integer pricePerSession;
+
+    @Schema(description = "평균 평점", example = "4.5")
+    private Double averageRating;
+
+    @Schema(description = "리뷰 수", example = "23")
+    private Long reviewCount;
+
+    @Schema(description = "시/도", example = "서울시")
+    private String city;
+
+    @Schema(description = "시/군/구", example = "강남구")
+    private String district;
+
+    @Schema(description = "소개 사진 URL 목록")
+    private List<String> photoUrls;
+}

--- a/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepository.java
+++ b/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
-public interface ProProfileRepository extends JpaRepository<ProProfile, Long> {
+public interface ProProfileRepository extends JpaRepository<ProProfile, Long>, ProProfileRepositoryCustom {
 	Optional<ProProfile> findByUser(Users user);
 	@Query("""
     SELECT p

--- a/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepositoryCustom.java
+++ b/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.grabpt.repository.ProProfileRepository;
+
+import com.grabpt.domain.entity.ProProfile;
+import com.grabpt.dto.request.ProSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProProfileRepositoryCustom {
+    Page<ProProfile> searchProfiles(ProSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepositoryCustomImpl.java
+++ b/src/main/java/com/grabpt/repository/ProProfileRepository/ProProfileRepositoryCustomImpl.java
@@ -1,0 +1,160 @@
+package com.grabpt.repository.ProProfileRepository;
+
+import com.grabpt.domain.entity.Address;
+import com.grabpt.domain.entity.Category;
+import com.grabpt.domain.entity.ProProfile;
+import com.grabpt.domain.entity.Review;
+import com.grabpt.domain.entity.Users;
+import com.grabpt.domain.enums.SortType;
+import com.grabpt.dto.request.ProSearchRequest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProProfileRepositoryCustomImpl implements ProProfileRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Page<ProProfile> searchProfiles(ProSearchRequest request, Pageable pageable) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<ProProfile> query = cb.createQuery(ProProfile.class);
+        Root<ProProfile> root = query.from(ProProfile.class);
+
+        Join<ProProfile, Users> userJoin = root.join("user", JoinType.LEFT);
+        Join<Users, Address> addressJoin = userJoin.join("address", JoinType.LEFT);
+        Join<ProProfile, Category> categoryJoin = root.join("category", JoinType.LEFT);
+
+        List<Predicate> predicates = buildPredicates(cb, query, root, userJoin, addressJoin, categoryJoin, request);
+        query.where(predicates.toArray(new Predicate[0]));
+        query.orderBy(buildOrderBy(cb, query, root, request.getSortBy()));
+        query.distinct(true);
+        query.select(root);
+
+        List<ProProfile> results = em.createQuery(query)
+            .setFirstResult((int) pageable.getOffset())
+            .setMaxResults(pageable.getPageSize())
+            .getResultList();
+
+        long total = countProfiles(cb, request);
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private List<Predicate> buildPredicates(
+        CriteriaBuilder cb,
+        CriteriaQuery<?> query,
+        Root<ProProfile> root,
+        Join<ProProfile, Users> userJoin,
+        Join<Users, Address> addressJoin,
+        Join<ProProfile, Category> categoryJoin,
+        ProSearchRequest request) {
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (hasText(request.getKeyword())) {
+            String kw = "%" + request.getKeyword() + "%";
+            predicates.add(cb.or(
+                cb.like(userJoin.get("nickname"), kw),
+                cb.like(root.get("center"), kw)
+            ));
+        }
+
+        if (hasText(request.getCategoryCode())) {
+            predicates.add(cb.equal(categoryJoin.get("code"), request.getCategoryCode()));
+        }
+
+        if (hasText(request.getCity())) {
+            predicates.add(cb.like(addressJoin.get("city"), "%" + request.getCity() + "%"));
+        }
+
+        if (hasText(request.getDistrict())) {
+            predicates.add(cb.like(addressJoin.get("district"), "%" + request.getDistrict() + "%"));
+        }
+
+        if (request.getMinPrice() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("pricePerSession"), request.getMinPrice()));
+        }
+
+        if (request.getMaxPrice() != null) {
+            predicates.add(cb.lessThanOrEqualTo(root.get("pricePerSession"), request.getMaxPrice()));
+        }
+
+        if (request.getMinRating() != null) {
+            Subquery<Double> avgSub = query.subquery(Double.class);
+            Root<Review> reviewRoot = avgSub.from(Review.class);
+            avgSub.select(cb.avg(reviewRoot.get("rating")));
+            avgSub.where(cb.equal(reviewRoot.get("proProfile"), root));
+            predicates.add(cb.greaterThanOrEqualTo(avgSub, request.getMinRating()));
+        }
+
+        return predicates;
+    }
+
+    private List<Order> buildOrderBy(
+        CriteriaBuilder cb,
+        CriteriaQuery<?> query,
+        Root<ProProfile> root,
+        SortType sortBy) {
+
+        List<Order> orders = new ArrayList<>();
+
+        if (sortBy == null) sortBy = SortType.RATING;
+
+        switch (sortBy) {
+            case RATING -> {
+                Subquery<Double> ratingSub = query.subquery(Double.class);
+                Root<Review> ratingRoot = ratingSub.from(Review.class);
+                ratingSub.select(cb.avg(ratingRoot.get("rating")));
+                ratingSub.where(cb.equal(ratingRoot.get("proProfile"), root));
+                orders.add(cb.desc(cb.coalesce(ratingSub, 0.0)));
+            }
+            case PRICE_ASC -> orders.add(cb.asc(root.get("pricePerSession")));
+            case PRICE_DESC -> orders.add(cb.desc(root.get("pricePerSession")));
+            case REVIEW_COUNT -> {
+                Subquery<Long> countSub = query.subquery(Long.class);
+                Root<Review> countRoot = countSub.from(Review.class);
+                countSub.select(cb.count(countRoot));
+                countSub.where(cb.equal(countRoot.get("proProfile"), root));
+                orders.add(cb.desc(cb.coalesce(countSub, 0L)));
+            }
+        }
+
+        orders.add(cb.desc(root.get("id")));
+        return orders;
+    }
+
+    private long countProfiles(CriteriaBuilder cb, ProSearchRequest request) {
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<ProProfile> root = countQuery.from(ProProfile.class);
+
+        Join<ProProfile, Users> userJoin = root.join("user", JoinType.LEFT);
+        Join<Users, Address> addressJoin = userJoin.join("address", JoinType.LEFT);
+        Join<ProProfile, Category> categoryJoin = root.join("category", JoinType.LEFT);
+
+        List<Predicate> predicates = buildPredicates(cb, countQuery, root, userJoin, addressJoin, categoryJoin, request);
+        countQuery.select(cb.countDistinct(root));
+        countQuery.where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(countQuery).getSingleResult();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/grabpt/service/ProProfileService/ProProfileService.java
+++ b/src/main/java/com/grabpt/service/ProProfileService/ProProfileService.java
@@ -5,6 +5,7 @@ import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.*;
 import com.grabpt.dto.response.CertificationResponseDTO;
 import com.grabpt.dto.response.ProProfileResponseDTO;
+import com.grabpt.dto.response.ProSearchResponse;
 import com.grabpt.dto.response.ProfileResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,4 +28,5 @@ public interface ProProfileService {
 	void updateProLocation(Long userId, ProLocationUpdateRequestDTO request);
 	String getProNicknameById(Long proProfileId);
 	ProProfile findByUser(Users user);
+	Page<ProSearchResponse> searchProfiles(ProSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/grabpt/service/ProProfileService/ProProfileServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ProProfileService/ProProfileServiceImpl.java
@@ -8,6 +8,7 @@ import com.grabpt.domain.entity.*;
 import com.grabpt.dto.request.*;
 import com.grabpt.dto.response.CertificationResponseDTO;
 import com.grabpt.dto.response.ProProfileResponseDTO;
+import com.grabpt.dto.response.ProSearchResponse;
 import com.grabpt.dto.response.ProfileResponseDTO;
 import com.grabpt.repository.ProProfileRepository.ProProfileRepository;
 import com.grabpt.repository.UserRepository.UserRepository;
@@ -22,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -173,6 +175,38 @@ public class ProProfileServiceImpl implements ProProfileService {
 	public ProProfile findByUser(Users user) {
 		return proProfileRepository.findByUser(user)
 			.orElseThrow(() -> new ProHandler(ErrorStatus.PRO_NOT_FOUND));
+	}
+
+	@Override
+	public Page<ProSearchResponse> searchProfiles(ProSearchRequest request, Pageable pageable) {
+		return proProfileRepository.searchProfiles(request, pageable)
+			.map(this::toSearchResponse);
+	}
+
+	private ProSearchResponse toSearchResponse(ProProfile profile) {
+		Users user = profile.getUser();
+		Address address = user != null ? user.getAddress() : null;
+
+		List<String> photoUrls = profile.getPhotos().stream()
+			.map(ProPhoto::getImageUrl)
+			.collect(Collectors.toList());
+
+		return ProSearchResponse.builder()
+			.proProfileId(profile.getId())
+			.userId(user != null ? user.getId() : null)
+			.nickname(user != null ? user.getNickname() : null)
+			.profileImageUrl(user != null ? user.getProfileImageUrl() : null)
+			.center(profile.getCenter())
+			.categoryCode(profile.getCategory() != null ? profile.getCategory().getCode() : null)
+			.categoryName(profile.getCategory() != null ? profile.getCategory().getName() : null)
+			.career(profile.getCareer())
+			.pricePerSession(profile.getPricePerSession())
+			.averageRating(profile.getAverageRating())
+			.reviewCount((long) profile.getReviews().size())
+			.city(address != null ? address.getCity() : null)
+			.district(address != null ? address.getDistrict() : null)
+			.photoUrls(photoUrls)
+			.build();
 	}
 
 	private Users findUserById(Long userId) {

--- a/src/main/java/com/grabpt/service/ProfileService/ProfileFacade.java
+++ b/src/main/java/com/grabpt/service/ProfileService/ProfileFacade.java
@@ -3,7 +3,9 @@ package com.grabpt.service.ProfileService;
 import com.grabpt.domain.entity.ProProfile;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.*;
+import com.grabpt.dto.request.ProSearchRequest;
 import com.grabpt.dto.response.*;
+import com.grabpt.dto.response.ProSearchResponse;
 import com.grabpt.service.ProProfileService.ProProfileService;
 import com.grabpt.service.UserActivityService.UserActivityService;
 import com.grabpt.service.UserProfileService.UserProfileService;
@@ -149,5 +151,10 @@ public class ProfileFacade implements ProfileService {
 	@Override
 	public ProProfile findByUser(Users user) {
 		return proProfileService.findByUser(user);
+	}
+
+	@Override
+	public Page<ProSearchResponse> searchProfiles(ProSearchRequest request, Pageable pageable) {
+		return proProfileService.searchProfiles(request, pageable);
 	}
 }

--- a/src/main/java/com/grabpt/service/ProfileService/ProfileService.java
+++ b/src/main/java/com/grabpt/service/ProfileService/ProfileService.java
@@ -10,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.grabpt.domain.entity.ProProfile;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.CenterUpdateRequestDTO;
+import com.grabpt.dto.request.ProSearchRequest;
+import com.grabpt.dto.response.ProSearchResponse;
 import com.grabpt.dto.request.CertificationUpdateRequestDTO;
 import com.grabpt.dto.request.DeletedRequestDTO;
 import com.grabpt.dto.request.DescriptionUpdateRequestDTO;
@@ -65,4 +67,6 @@ public interface ProfileService {
 	String getProNicknameById(Long proProfileId);
 
 	ProProfile findByUser(Users user);
+
+	Page<ProSearchResponse> searchProfiles(ProSearchRequest request, Pageable pageable);
 }


### PR DESCRIPTION
## PR 제목
- [Feat] 트레이너 찾기 검색 API 구현

## 변경 사항
- 키워드, 카테고리, 지역, 가격, 평점 조건 기반 트레이너 검색 API 구현
- JPA Criteria API를 활용한 동적 쿼리 처리
- 평점순 / 가격순 / 리뷰 많은 순 정렬 지원 (서브쿼리)
- 비인증 사용자도 접근 가능하도록 SecurityConfig 허용 처리

## 작업 내용 체크
- 기능 동작 확인 (로컬 테스트 완료)

## 관련 이슈
- 관련 이슈 번호: #471

## 기타 공유 사항
- `GET /api/pro/search` 엔드포인트, 모든 파라미터 optional
- 정렬: `RATING`(기본) / `PRICE_ASC` / `PRICE_DESC` / `REVIEW_COUNT`
- QueryDSL 미사용, JPA Criteria API로 구현
