### PR TITLE
fix: 채팅 내역 없는 채팅방 접속시 생기는 오류 해결

### DIFF
--- a/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
@@ -70,28 +70,28 @@ public class MessageServiceImpl implements MessageService{
 			.sum();
 	}
 
-
 	//채팅방 접속상태에서 message 읽은 경우
 	@Override
 	@Transactional
 	public void updateLastReadMessageWhenExist(Long roomId, Long userId) {
-		Messages messages = messageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId).orElseThrow(
-			()->new ChatHandler(ErrorStatus.MESSAGE_NOT_FOUND));
 
+		// 새로운 채팅방 생성 시 메시지 없을 때는 pass
+		messageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId)
+			.ifPresent((messages -> {
+				UserChatRoom chatRoom = userChatRoomService.findByRoomIdAndUserId(roomId, userId).orElseThrow(
+					() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_FOUND));
 
-		UserChatRoom chatRoom = userChatRoomService.findByRoomIdAndUserId(roomId, userId).orElseThrow(
-			() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_FOUND));
+				chatRoom.setLastReadMessageId(messages.getId());
+				chatRoom.setLastReadAt(LocalDateTime.now());
+				userChatRoomService.save(chatRoom);
 
-		chatRoom.setLastReadMessageId(messages.getId());
-		chatRoom.setLastReadAt(LocalDateTime.now());
-		userChatRoomService.save(chatRoom);
-
-		if (!messages.getSender().getId().equals(userId)) {
-			if (messages.getReadCount() > 0) {
-				messages.setReadCount(messages.getReadCount() - 1);
-			}
-			broadcastReadStatus(roomId, messages);
-		}
+				if (!messages.getSender().getId().equals(userId)) {
+					if (messages.getReadCount() > 0) {
+						messages.setReadCount(messages.getReadCount() - 1);
+					}
+					broadcastReadStatus(roomId, messages);
+				}
+			}));
 		updateAllUnreadMessageCount(userId);
 	}
 


### PR DESCRIPTION
## 개요
-기존에 채팅방 생성 후 메시지 내역이 없는 채팅방 접속시 401오류가 발생했습니다. 메시지 없는 상황에서 메시지를 조회하는 과정에서 
예외가 발생하였고 400에러가 발생해야하는데 이 부분은 프론트와의 소통 과정에서 401이 발생하지 않았나 생각됩니다.
## 변경 사항
- `MessageServiceImpl`: 메시지가 존재할 때만 로직 수행되도록 변경

## 작업 내용 체크
- 기능 동작 확인
- 로컬 스웨거 응답 확인

## 관련 이슈
- 관련 이슈 번호

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
