### PR TITLE
fix: StompHandler JWT 인증 활성화

### DIFF
--- a/src/main/java/com/grabpt/config/WebSocketConfig.java
+++ b/src/main/java/com/grabpt/config/WebSocketConfig.java
@@ -1,14 +1,24 @@
 package com.grabpt.config;
 
+import com.grabpt.config.stomp.StompHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+/**
+ * WebSocket/STOMP 설정
+ * Issue #475: StompHandler(JWT 인터셉터)를 configureClientInboundChannel에 등록
+ */
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final StompHandler stompHandler;
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -21,6 +31,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry.addEndpoint("/ws-connect")
 			.setAllowedOriginPatterns(
 				"http://localhost:5173",
+				"http://localhost:8080",
+				"http://localhost:8081",
 				"http://127.0.0.1:5173",
 				"https://grabpt.com",
 				"https://www.grabpt.com",
@@ -28,5 +40,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 				"*"
 			)
 			.withSockJS();
+	}
+
+	/**
+	 * STOMP CONNECT 시 JWT 인증을 수행하는 StompHandler를 인바운드 채널 인터셉터로 등록
+	 */
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(stompHandler);
 	}
 }

--- a/src/main/java/com/grabpt/config/stomp/StompHandler.java
+++ b/src/main/java/com/grabpt/config/stomp/StompHandler.java
@@ -1,50 +1,55 @@
-//package com.grabpt.config.stomp;
-//
-//import com.grabpt.config.jwt.JwtTokenProvider;
-//import com.grabpt.service.ChatService.ChatService;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.messaging.Message;
-//import org.springframework.messaging.MessageChannel;
-//import org.springframework.messaging.simp.stomp.StompCommand;
-//import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-//import org.springframework.messaging.support.ChannelInterceptor;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.userdetails.UserDetails;
-//import org.springframework.security.core.userdetails.UserDetailsService;
-//import org.springframework.stereotype.Component;
-//
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class StompHandler implements ChannelInterceptor {
-//
-//	private final JwtTokenProvider jwtTokenProvider;
-//	private final UserDetailsService userDetailsService;
-//
-//	@Override
-//	public Message<?> preSend(Message<?> message, MessageChannel channel) {
-//		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-//
-//		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-//			String token = accessor.getFirstNativeHeader("Authorization");
-//
-//			if (token != null && token.startsWith("Bearer ")) {
-//				token = token.substring(7); // Bearer 제거
-//
-//				if (jwtTokenProvider.validateToken(token)) {
-//					String username = jwtTokenProvider.getUserEmail(token);
-//					UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-//					UsernamePasswordAuthenticationToken auth =
-//						new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-//
-//					accessor.setUser(auth); // 여기서 Principal 설정!
-//				}
-//			}
-//		}
-//
-//		return message;
-//	}
-//}
-//
+package com.grabpt.config.stomp;
+
+import com.grabpt.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+/**
+ * STOMP CONNECT 시점에 JWT 토큰을 검증하고 Principal을 설정하는 인터셉터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserDetailsService userDetailsService;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+			String token = accessor.getFirstNativeHeader("Authorization");
+
+			if (token != null && token.startsWith("Bearer ")) {
+				token = token.substring(7);
+
+				if (jwtTokenProvider.validateToken(token)) {
+					String username = jwtTokenProvider.getUserEmail(token);
+					UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+					UsernamePasswordAuthenticationToken auth =
+						new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+					accessor.setUser(auth); // WebSocket Principal 설정
+					log.debug("[STOMP] JWT 인증 성공: {}", username);
+				} else {
+					log.warn("[STOMP] JWT 토큰 유효하지 않음");
+				}
+			} else {
+				log.warn("[STOMP] Authorization 헤더 없음 (비인증 연결 허용)");
+			}
+		}
+
+		return message;
+	}
+}


### PR DESCRIPTION
## PR 제목
- fix: StompHandler JWT 인증 활성화

## 변경 사항
- 기존 웹소켓 연결 시 JWT토큰 인증이 없었기 때문에 누구나 웹소켓에 접속할 수 있었으나 StompHandler의 ChannelInterceptor구현을 통해 최초 접속시 토큰 검증

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #475 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
