### PR TITLE
[Feat] 채팅 시스템 분산 서버 환경 대응을 위한 Redis Pub/Sub 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 
     // Caffeine Cache
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -19,6 +19,11 @@ services:
       retries: 10
     restart: unless-stopped
 
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+
   app:
     build:
       context: .
@@ -33,6 +38,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/grabpt?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: grabpt
       SPRING_DATASOURCE_PASSWORD: grabptDB2025
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,19 @@ services:
       retries: 10
     restart: unless-stopped
 
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
   app:
     image: ${ECR_REGISTRY}/${ECR_REPO}:${IMAGE_TAG:-latest}
     depends_on:
       mysql:
         condition: service_healthy
+      redis:
+        condition: service_started
     env_file:
       - /home/ubuntu/.env.properties
     environment:
@@ -31,6 +39,8 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: ${DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
     volumes:
       - /home/ubuntu/.env.properties:/app/.env.properties:ro

--- a/src/main/java/com/grabpt/config/redis/RedisConfig.java
+++ b/src/main/java/com/grabpt/config/redis/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.grabpt.config.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.grabpt.service.ChatService.redis.ChatRedisSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,8 +47,11 @@ public class RedisConfig {
 		template.setHashKeySerializer(new StringRedisSerializer());
 
 		// Value는 JSON으로 저장
-		GenericJackson2JsonRedisSerializer jsonSerializer
-			= new GenericJackson2JsonRedisSerializer();
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 		template.setValueSerializer(jsonSerializer);
 		template.setHashValueSerializer(jsonSerializer);
 

--- a/src/main/java/com/grabpt/config/redis/RedisConfig.java
+++ b/src/main/java/com/grabpt/config/redis/RedisConfig.java
@@ -1,10 +1,13 @@
 package com.grabpt.config.redis;
 
+import com.grabpt.service.ChatService.redis.ChatRedisSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -15,10 +18,19 @@ public class RedisConfig {
 	* Pub/Sub 메시지를 처리하는 리스너 컨테이너
 	*/
 	@Bean
-	public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory){
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+		RedisConnectionFactory connectionFactory,
+		MessageListenerAdapter listenerAdapter)
+	{
 		RedisMessageListenerContainer listenerContainer = new RedisMessageListenerContainer();
 		listenerContainer.setConnectionFactory(connectionFactory);
+		listenerContainer.addMessageListener(listenerAdapter, new PatternTopic("chat:room:*"));
 		return listenerContainer;
+	}
+
+	@Bean
+	public MessageListenerAdapter listenerAdapter(ChatRedisSubscriber subscriber){
+		return new MessageListenerAdapter(subscriber, "onMessage");
 	}
 
 	@Bean

--- a/src/main/java/com/grabpt/config/redis/RedisConfig.java
+++ b/src/main/java/com/grabpt/config/redis/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.grabpt.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	/**
+	* Pub/Sub 메시지를 처리하는 리스너 컨테이너
+	*/
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory){
+		RedisMessageListenerContainer listenerContainer = new RedisMessageListenerContainer();
+		listenerContainer.setConnectionFactory(connectionFactory);
+		return listenerContainer;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory){
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+		template.setConnectionFactory(connectionFactory);
+
+		// Key는 문자열로 저장
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		// Value는 JSON으로 저장
+		GenericJackson2JsonRedisSerializer jsonSerializer
+			= new GenericJackson2JsonRedisSerializer();
+		template.setValueSerializer(jsonSerializer);
+		template.setHashValueSerializer(jsonSerializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+}

--- a/src/main/java/com/grabpt/config/websocket/StompHandler.java
+++ b/src/main/java/com/grabpt/config/websocket/StompHandler.java
@@ -1,4 +1,4 @@
-package com.grabpt.config.stomp;
+package com.grabpt.config.websocket;
 
 import com.grabpt.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/grabpt/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/grabpt/config/websocket/WebSocketConfig.java
@@ -1,6 +1,5 @@
-package com.grabpt.config;
+package com.grabpt.config.websocket;
 
-import com.grabpt.config.stomp.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;

--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -50,6 +50,26 @@ public class ChatController {
 	}
 
 	@Operation(
+		description = "Swagger 테스트용 채팅 메시지 전송 API (STOMP 웹소켓 전송과 동일하게 동작하며 Redis Pub/Sub을 탑니다.)",
+		summary = "채팅 메시지 전송 API (REST)"
+	)
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메시지 전송 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+	})
+	@PostMapping("/api/chat/{roomId}/messages")
+	@ResponseBody
+	public ApiResponse<String> sendMessageApi(@PathVariable(name = "roomId") Long roomId, @RequestBody ChatRequest.MessageRequestDto request){
+		Messages newMessage = chatFacade.createChatMessage(request);
+		ChatResponse.MessageResponseDto response = ChatConverter.toMessageResponseDto(newMessage);
+		log.info("채팅 메시지 브로드캐스트 (REST API): {}", response.getContent());
+
+		redisPublisher.publish(roomId, response);
+		return ApiResponse.onSuccess("메시지 전송 성공");
+	}
+
+	@Operation(
 		description = "유저가 채팅방에 접속 상태일 경우 실시간으로 메시지를 읽음 처리합니다(인증 토큰 필요, roomId는 pathVariable",
 		summary = "채팅방 접속 상태일 시 메시지 읽음 처리"
 	)

--- a/src/main/java/com/grabpt/controller/ChatController.java
+++ b/src/main/java/com/grabpt/controller/ChatController.java
@@ -10,6 +10,7 @@ import com.grabpt.dto.response.ChatRoomPreviewDto;
 import com.grabpt.service.ChatService.ChatFacade;
 import com.grabpt.service.ChatService.ChatRoomService;
 import com.grabpt.service.ChatService.MessageService;
+import com.grabpt.service.ChatService.redis.ChatRedisPublisher;
 import com.grabpt.service.UserService.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,7 +35,7 @@ public class ChatController {
 	private final ChatRoomService chatRoomService;
 	private final MessageService messageService;
 	private final ChatFacade chatFacade;
-	private final UserQueryService userQueryService;
+	private final ChatRedisPublisher redisPublisher;
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@MessageMapping("/chat/{roomId}")
@@ -42,7 +43,10 @@ public class ChatController {
 		Messages newMessage = chatFacade.createChatMessage(request);
 		ChatResponse.MessageResponseDto response = ChatConverter.toMessageResponseDto(newMessage);
 		log.info("채팅 메시지 브로드캐스트", response.getContent());
-		messagingTemplate.convertAndSend("/subscribe/chat/"+roomId, response);
+
+		//Redis를 통해 전달 (모든 서버 인스턴스에 브로드캐스트됨)
+		redisPublisher.publish(roomId, response);
+		//messagingTemplate.convertAndSend("/subscribe/chat/"+roomId, response);
 	}
 
 	@Operation(

--- a/src/main/java/com/grabpt/service/ChatService/redis/ChatRedisPublisher.java
+++ b/src/main/java/com/grabpt/service/ChatService/redis/ChatRedisPublisher.java
@@ -1,0 +1,18 @@
+package com.grabpt.service.ChatService.redis;
+
+import com.grabpt.dto.response.ChatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRedisPublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void publish(Long roomId, ChatResponse.MessageResponseDto message){
+		redisTemplate.convertAndSend("chat:room:" + roomId, message);
+	}
+}
+

--- a/src/main/java/com/grabpt/service/ChatService/redis/ChatRedisSubscriber.java
+++ b/src/main/java/com/grabpt/service/ChatService/redis/ChatRedisSubscriber.java
@@ -1,0 +1,33 @@
+package com.grabpt.service.ChatService.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grabpt.dto.response.ChatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRedisSubscriber implements MessageListener {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final ObjectMapper objectMapper;
+
+
+	// Redis에 새로운 메시지 도착했을 때 실행할 로직
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			ChatResponse.MessageResponseDto dto =
+				objectMapper.readValue(message.getBody(), ChatResponse.MessageResponseDto.class);
+			messagingTemplate.convertAndSend("/subscribe/chat/"+dto.getRoomId(), dto);
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
## PR 제목
- [Feat] 채팅 시스템 분산 서버 환경 대응을 위한 Redis Pub/Sub 도입

## 변경 사항
- Redis 의존성 및 설정 추가: spring-boot-starter-data-redis 추가 및 RedisConfig (직렬화, MessageListenerContainer) 구현

- 메시지 브로드캐스트 아키텍처 변경:
기존: SimpMessagingTemplate을 통한 단일 서버 내부 메시지 전송
변경: ChatRedisPublisher를 통해 Redis 채널에 Publish 후, 각 서버의 ChatRedisSubscriber가 수신하여 로컬 웹소켓 클라이언트들에게 메시지를 전송하는 구조로 개선

- 인프라 구성 추가: docker-compose.yml 및 docker-compose.local.yml에 Redis 컨테이너 추가 및 app 서비스와 의존성 연결


## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #476 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
