### PR TITLE
[Refactor] 채팅방 목록 조회 API Redis를 활용한 성능 개선

### DIFF
--- a/load-test/chat-room-list.js
+++ b/load-test/chat-room-list.js
@@ -1,0 +1,45 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// 테스트 옵션 설정
+export const options = {
+    // 가상 유저(VUs) 수와 지속 시간 설정
+    stages: [
+        { duration: '5s', target: 50 },  // 5초 동안 50명까지 점진적으로 증가
+        { duration: '15s', target: 50 }, // 15초 동안 50명 유지
+        { duration: '5s', target: 0 },   // 5초 동안 0명으로 감소
+    ],
+    // 성능 목표 설정 (포트폴리오에 쓰기 좋은 지표)
+    thresholds: {
+        http_req_duration: ['p(95)<500'], // 95%의 요청이 500ms 이하로 처리되어야 함
+        http_req_failed: ['rate<0.01'],   // 에러율이 1% 미만이어야 함
+    },
+};
+
+// 테스트할 환경 변수 (토큰은 실행할 때 터미널에서 주입하거나 여기에 하드코딩)
+const BASE_URL = 'http://localhost:8080';
+const TOKEN = __ENV.TOKEN || '여기에_실제_JWT_토큰_입력';
+
+// 가상 유저 1명이 수행할 시나리오
+export default function () {
+    // 테스트할 API: 채팅방 목록 조회 (안읽음 카운트 포함)
+    const url = `${BASE_URL}/chatRoom/list`;
+
+    const params = {
+        headers: {
+            'Authorization': `Bearer ${TOKEN}`,
+            'Content-Type': 'application/json',
+        },
+    };
+
+    // GET 요청 보내기
+    const res = http.get(url, params);
+
+    // 응답 검증 (200 OK 인지 확인)
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    // 1초 대기 (유저가 새로고침 누르는 텀을 흉내냄)
+    sleep(1);
+}

--- a/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
+++ b/src/main/java/com/grabpt/repository/ChatRepository/MessageRepository.java
@@ -46,29 +46,30 @@ public interface MessageRepository extends JpaRepository<Messages, Long> {
 	""")
 	void markAsReadAllInRoom(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
-	@Query("""
-    SELECT m.chatRoom.id, COUNT(m)
-       FROM Messages m
-       JOIN m.chatRoom r
-       WHERE r.id IN :roomIds
-       AND m.id > (
-            SELECT COALESCE(ucr.lastReadMessageId, 0)
-            FROM UserChatRoom ucr
-            WHERE ucr.chatRoom.id = m.chatRoom.id AND ucr.user.id = :userId
-       )
-       AND m.sender.id <> :userId
-       GROUP BY m.chatRoom.id
-	""")
-	List<Object[]> countUnreadMessages(@Param("roomIds") List<Long> roomIds, @Param("userId") Long userId);
-
-	default Map<Long, Long> getUnreadCountMap(List<Long> roomIds, Long userId) {
-		List<Object[]> results = countUnreadMessages(roomIds, userId);
-		return results.stream()
-			.collect(Collectors.toMap(
-				result -> (Long) result[0],  // roomId
-				result -> (Long) result[1]   // count
-			));
-	}
+	// legacy
+//	@Query("""
+//    SELECT m.chatRoom.id, COUNT(m)
+//       FROM Messages m
+//       JOIN m.chatRoom r
+//       WHERE r.id IN :roomIds
+//       AND m.id > (
+//            SELECT COALESCE(ucr.lastReadMessageId, 0)
+//            FROM UserChatRoom ucr
+//            WHERE ucr.chatRoom.id = m.chatRoom.id AND ucr.user.id = :userId
+//       )
+//       AND m.sender.id <> :userId
+//       GROUP BY m.chatRoom.id
+//	""")
+//	List<Object[]> countUnreadMessages(@Param("roomIds") List<Long> roomIds, @Param("userId") Long userId);
+//
+//	default Map<Long, Long> getUnreadCountMap(List<Long> roomIds, Long userId) {
+//		List<Object[]> results = countUnreadMessages(roomIds, userId);
+//		return results.stream()
+//			.collect(Collectors.toMap(
+//				result -> (Long) result[0],  // roomId
+//				result -> (Long) result[1]   // count
+//			));
+//	}
 }
 
 

--- a/src/main/java/com/grabpt/service/ChatService/ChatFacade.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatFacade.java
@@ -9,6 +9,7 @@ import com.grabpt.domain.entity.Messages;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.service.AlarmService.AlarmService;
+import com.grabpt.service.ChatService.redis.UnreadCountChatService;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -23,6 +24,7 @@ public class ChatFacade {
 	private final ChatRoomService chatRoomService;
 	private final UserChatRoomService userChatRoomService;
 	private final AlarmService alarmService;
+	private final UnreadCountChatService unreadCountChatService;
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@Transactional //Message
@@ -38,6 +40,9 @@ public class ChatFacade {
 		Messages save = messageService.save(newMessage);
 
 		Long otherUserId = userChatRoomService.getOtherUserId(sender.getId(), chatRoom.getId());
+
+		// 안읽음 카운트 조회 및 전달
+		unreadCountChatService.incrementUnreadCount(chatRoom.getId(), otherUserId);
 		Long allUnreadMessageCount = messageService.getAllUnreadMessageCount(otherUserId);
 		messagingTemplate.convertAndSend("/subscribe/chat/"+otherUserId+"/unread-count", allUnreadMessageCount);
 

--- a/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
@@ -4,14 +4,12 @@ import com.grabpt.apiPayload.code.status.ErrorStatus;
 import com.grabpt.apiPayload.exception.handler.ChatHandler;
 import com.grabpt.apiPayload.exception.handler.UserHandler;
 import com.grabpt.converter.ChatConverter;
-import com.grabpt.domain.entity.ChatRooms;
 import com.grabpt.domain.entity.Messages;
 import com.grabpt.domain.entity.UserChatRoom;
 import com.grabpt.domain.entity.Users;
-import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.dto.response.ChatResponse;
 import com.grabpt.repository.ChatRepository.MessageRepository;
-import com.grabpt.service.AlarmService.AlarmService;
+import com.grabpt.service.ChatService.redis.UnreadCountChatService;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +30,10 @@ import java.util.stream.Collectors;
 public class MessageServiceImpl implements MessageService{
 
 	private final MessageRepository messageRepository;
-
 	private final UserQueryService userQueryService;
 	private final UserChatRoomService userChatRoomService;
 	private final SimpMessagingTemplate messagingTemplate;
-	private final AlarmService alarmService;
+	private final UnreadCountChatService unreadCountChatService;
 
 	@Override //Message
 	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor) {
@@ -54,7 +51,8 @@ public class MessageServiceImpl implements MessageService{
 	//상대가 보낸 메시지중 lastReadMessageId보다 큰 메시지 수
 	@Override //Message
 	public Map<Long, Long> getUnreadMessageCount(List<Long> roomIds, Long userId){
-		return messageRepository.getUnreadCountMap(roomIds, userId);
+		// regacy: return messageRepository.getUnreadCountMap(roomIds, userId);
+		return unreadCountChatService.getUnreadCounts(roomIds, userId);
 	}
 
 	@Override //Message
@@ -74,6 +72,8 @@ public class MessageServiceImpl implements MessageService{
 	@Override
 	@Transactional
 	public void updateLastReadMessageWhenExist(Long roomId, Long userId) {
+
+		unreadCountChatService.resetUnreadCount(roomId, userId);
 
 		// 새로운 채팅방 생성 시 메시지 없을 때는 pass
 		messageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId)
@@ -99,7 +99,9 @@ public class MessageServiceImpl implements MessageService{
 	@Override
 	@Transactional
 	public void updateLastReadMessageWhenEnter(Long roomId, Long userId){
-		long startTime = System.currentTimeMillis(); // 시작 시간 측정
+
+		unreadCountChatService.resetUnreadCount(roomId, userId);
+
 		List<Messages> unreadMessages = messageRepository.findUnreadMessages(roomId, userId);
 
 		if(!unreadMessages.isEmpty()){
@@ -121,9 +123,6 @@ public class MessageServiceImpl implements MessageService{
 
 
 		updateAllUnreadMessageCount(userId);
-		long endTime = System.currentTimeMillis(); // 종료 시간 측정
-		long duration = endTime - startTime; // 실행 시간 계산
-		log.info("실행시간:{}",duration);
 	}
 
 	@Override

--- a/src/main/java/com/grabpt/service/ChatService/redis/UnreadCountChatService.java
+++ b/src/main/java/com/grabpt/service/ChatService/redis/UnreadCountChatService.java
@@ -1,0 +1,58 @@
+package com.grabpt.service.ChatService.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UnreadCountChatService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private String generateKey(Long roomId, Long userId){
+		return "chat:unread:"+roomId+":"+userId;
+	}
+
+	public void incrementUnreadCount(Long roomId, Long userId){
+		String key = generateKey(roomId, userId);
+		redisTemplate.opsForValue().increment(key);
+		log.info("Redis Unread Increment: [{}]", key);
+	}
+
+	public void resetUnreadCount(Long roomId, Long userId){
+		String key = generateKey(roomId, userId);
+		redisTemplate.opsForValue().set(key, "0");
+		log.info("Redis Unread Reset: [{}]", key);
+	}
+
+	public Map<Long, Long> getUnreadCounts(List<Long> roomIds, Long userId){
+		if(roomIds==null || roomIds.isEmpty()){
+			return new HashMap<>();
+		}
+		List<String> keys = roomIds.stream()
+			.map(roomId -> generateKey(roomId, userId))
+			.toList();
+
+		// Redis MGET
+		List<Object> values = redisTemplate.opsForValue().multiGet(keys);
+
+		Map<Long, Long> resultMap = new HashMap<>();
+		for(int i=0; i<roomIds.size(); i++){
+			Long roomId = roomIds.get(i);
+			Object value = values != null ? values.get(i) : null;
+
+			Long unreadCount = (value == null) ? 0L : Long.parseLong(value.toString());
+			resultMap.put(roomId, unreadCount);
+		}
+
+		return resultMap;
+	}
+}


### PR DESCRIPTION
## PR 제목
- [Refactor] 채팅방 목록 조회 API Redis를 활용한 성능 개선

## 변경 사항
- 기존 채팅방 목록 조회 시 읽지 않은 메시지 개수를 가져오는데 있어 서브쿼리 + GROUB BY방식을 사용해 수많은 쿼리가 발생하였음 -> Redis 캐싱을 활용하여 안읽은 메시지 개수를 상황에 따라 처리 (Redis MGET)

### 📊 캐싱 전/후 성능 비교

| 지표 | 개선 전 (MySQL) | 개선 후 (Redis) | 변화량 |
|---|---|---|---|
| **p(95) 응답 속도** | 4.63초 (4,630ms) | **0.76초 (766ms)** | 🔥 **83.4% 시간 단축!** |
| **평균 응답 속도** | 1.63초 (1,630ms) | **0.21초 (212ms)** | 🔥 **87.0% 시간 단축!** |
| **최대 응답 속도** | 10.6초 | **1.76초** | 🔥 **83.3% 시간 단축!** |
| **TPS (처리량)** | 15.1 req/s | **32.8 req/s** | 🚀 **2.1배 이상 증가!** |

## 작업 내용 체크
- 기능 동작 확인

## 관련 이슈
- 관련 이슈 번호: #477 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
