### PR TITLE
[Refactor] 최근 메시지 조회 Redis 캐싱

### DIFF
--- a/load-test/chat-room-messages.js
+++ b/load-test/chat-room-messages.js
@@ -1,0 +1,34 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '10s', target: 50 }, // 10초 동안 동시 접속(연결) 50개로 증가
+        { duration: '10s', target: 50 }, // 10초 동안 유지 (서버 뚜들겨 패기)
+        { duration: '5s', target: 0 },   // 5초 동안 서서히 종료
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<500'], // 95%의 응답이 500ms 이내여야 함
+    },
+};
+
+export default function () {
+    // 💡 roomId를 1번으로 수정했습니다!
+    const url = 'http://localhost:8080/chatRoom/1/messages?cursor=0';
+    const token = __ENV.TOKEN;
+
+    const params = {
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+        },
+    };
+
+    const res = http.get(url, params);
+
+    check(res, {
+        'is status 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/src/main/java/com/grabpt/service/ChatService/ChatFacade.java
+++ b/src/main/java/com/grabpt/service/ChatService/ChatFacade.java
@@ -9,6 +9,7 @@ import com.grabpt.domain.entity.Messages;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.request.ChatRequest;
 import com.grabpt.service.AlarmService.AlarmService;
+import com.grabpt.service.ChatService.redis.RecentMessageCacheService;
 import com.grabpt.service.ChatService.redis.UnreadCountChatService;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class ChatFacade {
 	private final UserChatRoomService userChatRoomService;
 	private final AlarmService alarmService;
 	private final UnreadCountChatService unreadCountChatService;
+	private final RecentMessageCacheService recentMessageCacheService;
 	private final SimpMessagingTemplate messagingTemplate;
 
 	@Transactional //Message
@@ -36,8 +38,10 @@ public class ChatFacade {
 		ChatRooms chatRoom = chatRoomService.findById(request.getRoomId()).orElseThrow(
 			() -> new ChatHandler(ErrorStatus.CHATROOM_NOT_FOUND));
 
+		// 메시지를 저장한 후 Redis 캐시에도 저장합니다
 		Messages newMessage = ChatConverter.toMessage(request, sender, chatRoom);
 		Messages save = messageService.save(newMessage);
+		recentMessageCacheService.saveMessage(chatRoom.getId(), ChatConverter.toMessageResponseDto(save));
 
 		Long otherUserId = userChatRoomService.getOtherUserId(sender.getId(), chatRoom.getId());
 

--- a/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
+++ b/src/main/java/com/grabpt/service/ChatService/MessageServiceImpl.java
@@ -9,6 +9,7 @@ import com.grabpt.domain.entity.UserChatRoom;
 import com.grabpt.domain.entity.Users;
 import com.grabpt.dto.response.ChatResponse;
 import com.grabpt.repository.ChatRepository.MessageRepository;
+import com.grabpt.service.ChatService.redis.RecentMessageCacheService;
 import com.grabpt.service.ChatService.redis.UnreadCountChatService;
 import com.grabpt.service.UserService.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -34,11 +35,24 @@ public class MessageServiceImpl implements MessageService{
 	private final UserChatRoomService userChatRoomService;
 	private final SimpMessagingTemplate messagingTemplate;
 	private final UnreadCountChatService unreadCountChatService;
+	private final RecentMessageCacheService recentMessageCacheService;
 
 	@Override //Message
 	public List<ChatResponse.MessageResponseDto> getMessagesByChatRoom(Long roomId, Long cursor) {
-		if(cursor == null){
-			cursor = 0L;
+		if(cursor == null || cursor == 0L){
+			List<ChatResponse.MessageResponseDto> recentMessages =
+				recentMessageCacheService.getRecentMessages(roomId);
+			// Cache hit
+			if(!recentMessages.isEmpty()){
+				return recentMessages;
+			}
+			// Cache miss
+			Pageable cachePageable = PageRequest.of(0, 50);
+			List<Messages> messagesByCursor = messageRepository.findMessagesByCursor(roomId, 0L, cachePageable);
+			List<ChatResponse.MessageResponseDto> cacheDto =
+				messagesByCursor.stream().map(ChatConverter::toMessageResponseDto).toList();
+			recentMessageCacheService.loadMessageToCache(roomId, cacheDto);
+			return cacheDto.stream().limit(20).toList();
 		}
 		Pageable pageable = PageRequest.of(0, 20);
 

--- a/src/main/java/com/grabpt/service/ChatService/redis/RecentMessageCacheService.java
+++ b/src/main/java/com/grabpt/service/ChatService/redis/RecentMessageCacheService.java
@@ -1,0 +1,52 @@
+package com.grabpt.service.ChatService.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grabpt.dto.response.ChatResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecentMessageCacheService {
+
+	private final RedisTemplate<String, Object>	redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void saveMessage(Long roomId, ChatResponse.MessageResponseDto dto){
+		String key = generateKey(roomId);
+
+		redisTemplate.opsForList().leftPush(key, dto);
+		redisTemplate.opsForList().trim(key, 0, 49);
+	}
+
+	public List<ChatResponse.MessageResponseDto> getRecentMessages(Long roomId){
+		String key = generateKey(roomId);
+		List<Object> messages = redisTemplate.opsForList().range(key, 0, 19);
+
+		if(messages == null || messages.isEmpty()){
+			return new ArrayList<>();
+		}
+
+		return messages.stream()
+			.map(obj -> objectMapper.convertValue(obj, ChatResponse.MessageResponseDto.class))
+			.toList();
+	}
+
+
+	public void loadMessageToCache(Long roomId, List<ChatResponse.MessageResponseDto> messages){
+		if(messages == null || messages.isEmpty()){
+			return;
+		}
+		String key = generateKey(roomId);
+		redisTemplate.delete(key);
+		redisTemplate.opsForList().rightPushAll(key, messages.toArray());
+	}
+
+	private String generateKey(Long roomId){
+		return "chat:room_messages:"+roomId;
+	}
+}


### PR DESCRIPTION
## PR 제목
- [Refactor] 최근 메시지 조회 Redis 캐싱

## 변경 사항
- 기존 DB에서 메시지를 조회 -> 최근 20개 메시지를 Redis 캐싱을 사용하여 조회
- RecentMessageCacheService 추가

## 작업 내용 체크
- 기능 동작 확인
- 부하 테스트 -> 조회 속도 10%개선

## 관련 이슈
- 관련 이슈 번호: #478 

## 기타 공유 사항
- 테스트 시 유의사항이나 논의할 포인트 등
